### PR TITLE
Refactor to pass bearer token and project id header

### DIFF
--- a/internal/pkg/cli/command/config/set_api_key.go
+++ b/internal/pkg/cli/command/config/set_api_key.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
-	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +14,8 @@ func NewSetApiKeyCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			newApiKey := args[0]
 			secrets.ApiKey.Set(newApiKey)
-			pcio.Printf("Config property %s updated. To clear saved keys, run %s.\n", style.Emphasis("api_key"), style.Code("pinecone logout"))
+			msg.SuccessMsg("Config property %s updated.", style.Emphasis("api_key"))
+			msg.InfoMsg("To clear saved keys, run %s.", style.Code("pinecone logout"))
 		},
 	}
 

--- a/internal/pkg/utils/sdk/client.go
+++ b/internal/pkg/utils/sdk/client.go
@@ -55,7 +55,7 @@ func newClientForUserFromTarget() *pinecone.Client {
 	oauth2Token := secrets.OAuth2Token.Get()
 
 	if oauth2Token.AccessToken == "" {
-		msg.FailMsg("You need to either set an API key with %s or login and run %s to login and set a target project", style.Code("pinecone config set-api-key"), style.Code("pinecone target"))
+		msg.FailMsg("Please set an API key with %s or login with %s before attempting this operation.", style.Code("pinecone config set-api-key"), style.Code("pinecone login"))
 		exit.ErrorMsg("User is not logged in")
 	}
 


### PR DESCRIPTION
## Problem

Some public APIs were recently modified to accept a user access token. That's more convenient that having users find and copy around an API key.

## Solution

- Use new Pinecone client constructor from golang SDK. 
- Use an API token if it is set. Otherwise, use the access token and target project if they are set. Otherwise, error out.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- Verify I can still perform actions such as list / describe index.
- `PINECONE_LOG_LEVEL=DEBUG` to confirm I am on the code path I expect
- Logout and attempt to use these commands to confirm the error messages are helpful