### PR TITLE
Interactive assistant targeting, code readability chores

### DIFF
--- a/internal/pkg/assistants/assistant_chat_completions.go
+++ b/internal/pkg/assistants/assistant_chat_completions.go
@@ -13,16 +13,16 @@ const (
 	URL_ASSISTANT_CHAT_COMPLETIONS = "/assistant/chat/%s/chat/completions"
 )
 
-func GetAssistantChatCompletions(kmName string, msg string) (*models.ChatCompletionModel, error) {
+func GetAssistantChatCompletions(asstName string, msg string) (*models.ChatCompletionModel, error) {
 	outgoingMsg := models.ChatCompletionMessage{
 		Role:    "user",
 		Content: msg,
 	}
 	chatHistory := state.ChatHist.Get()
-	chat, exists := (*chatHistory.History)[kmName]
+	chat, exists := (*chatHistory.History)[asstName]
 	if !exists {
 		chat = models.AssistantChat{}
-		(*chatHistory.History)[kmName] = chat
+		(*chatHistory.History)[asstName] = chat
 	}
 
 	// Add new outgoing messages to existing conversation, this becomes the body
@@ -39,7 +39,7 @@ func GetAssistantChatCompletions(kmName string, msg string) (*models.ChatComplet
 
 	resp, err := network.PostAndDecode[models.ChatCompletionRequest, models.ChatCompletionModel](
 		assistantDataUrl,
-		fmt.Sprintf(URL_ASSISTANT_CHAT_COMPLETIONS, kmName),
+		fmt.Sprintf(URL_ASSISTANT_CHAT_COMPLETIONS, asstName),
 		true,
 		body,
 	)
@@ -49,7 +49,7 @@ func GetAssistantChatCompletions(kmName string, msg string) (*models.ChatComplet
 
 	// If the request was successful, update the chat history
 	chat.Messages = append(chat.Messages, processChatCompletionModel(resp)...)
-	(*chatHistory.History)[kmName] = chat
+	(*chatHistory.History)[asstName] = chat
 	state.ChatHist.Set(&chatHistory)
 
 	return resp, nil

--- a/internal/pkg/assistants/assistant_file_delete.go
+++ b/internal/pkg/assistants/assistant_file_delete.go
@@ -13,7 +13,7 @@ const (
 
 type DeleteAssistantFileResponse string
 
-func DeleteKnowledgeFile(kmName string, fileId string) (*DeleteAssistantFileResponse, error) {
+func DeleteAssistantFile(kmName string, fileId string) (*DeleteAssistantFileResponse, error) {
 	assistantDataUrl, err := GetAssistantDataBaseUrl()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/assistants/assistant_file_delete.go
+++ b/internal/pkg/assistants/assistant_file_delete.go
@@ -13,7 +13,7 @@ const (
 
 type DeleteAssistantFileResponse string
 
-func DeleteAssistantFile(kmName string, fileId string) (*DeleteAssistantFileResponse, error) {
+func DeleteAssistantFile(asstName string, fileId string) (*DeleteAssistantFileResponse, error) {
 	assistantDataUrl, err := GetAssistantDataBaseUrl()
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func DeleteAssistantFile(kmName string, fileId string) (*DeleteAssistantFileResp
 
 	resp, err := network.RequestWithoutBodyAndDecode[DeleteAssistantFileResponse](
 		assistantDataUrl,
-		pcio.Sprintf(URL_DELETE_ASSISTANT_FILE, kmName, fileId),
+		pcio.Sprintf(URL_DELETE_ASSISTANT_FILE, asstName, fileId),
 		http.MethodDelete,
 		true,
 	)

--- a/internal/pkg/assistants/delete.go
+++ b/internal/pkg/assistants/delete.go
@@ -11,18 +11,18 @@ const (
 	URL_DELETE_ASSISTANT = "/assistant/assistants/%s"
 )
 
-type DeleteKnowledgeModelResponse struct {
+type DeleteAssistantResponse struct {
 	Success bool `json:"success"`
 }
 
-func DeleteAssistant(name string) (*DeleteKnowledgeModelResponse, error) {
+func DeleteAssistant(name string) (*DeleteAssistantResponse, error) {
 
 	assistantControlUrl, err := GetAssistantControlBaseUrl()
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := network.RequestWithoutBodyAndDecode[DeleteKnowledgeModelResponse](
+	resp, err := network.RequestWithoutBodyAndDecode[DeleteAssistantResponse](
 		assistantControlUrl,
 		pcio.Sprintf(URL_DELETE_ASSISTANT, name),
 		http.MethodDelete,

--- a/internal/pkg/assistants/list.go
+++ b/internal/pkg/assistants/list.go
@@ -56,13 +56,13 @@ func ListAssistants() (*ListAssistantsResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, model := range resp.Assistants {
+	for _, assistant := range resp.Assistants {
 		log.Trace().
-			Str("name", model.Name).
-			Str("status", string(model.Status)).
-			Str("created_at", model.CreatedAt).
-			Str("updated_at", model.UpdatedAt).
-			Str("metadata", model.Metadata.ToString()).
+			Str("name", assistant.Name).
+			Str("status", string(assistant.Status)).
+			Str("created_at", assistant.CreatedAt).
+			Str("updated_at", assistant.UpdatedAt).
+			Str("metadata", assistant.Metadata.ToString()).
 			Msg("found assistant")
 	}
 	return resp, nil

--- a/internal/pkg/assistants/list.go
+++ b/internal/pkg/assistants/list.go
@@ -21,8 +21,8 @@ type AssistantModel struct {
 
 type AssistantMetadata map[string]interface{}
 
-func (kmm *AssistantMetadata) ToString() string {
-	jsonData, err := json.Marshal(kmm)
+func (am *AssistantMetadata) ToString() string {
+	jsonData, err := json.Marshal(am)
 	if err != nil {
 		return "ERROR: could not parse AssistantMetadata to string"
 	}

--- a/internal/pkg/cli/command/assistant/chat_clear.go
+++ b/internal/pkg/cli/command/assistant/chat_clear.go
@@ -20,9 +20,9 @@ func NewAssistantChatClearCmd() *cobra.Command {
 		Use:   "clear",
 		Short: "Clear chat history",
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.name = targetAsst
 			}
 			if options.name == "" {
 				pcio.Printf("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))

--- a/internal/pkg/cli/command/assistant/chat_describe.go
+++ b/internal/pkg/cli/command/assistant/chat_describe.go
@@ -10,8 +10,8 @@ import (
 )
 
 type AssistantChatDescribeCmdOptions struct {
-	json bool
-	name string
+	assistant string
+	json      bool
 }
 
 func NewAssistantChatDescribeCmd() *cobra.Command {
@@ -21,19 +21,19 @@ func NewAssistantChatDescribeCmd() *cobra.Command {
 		Use:   "describe",
 		Short: "Describe an assistant chat",
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.assistant = targetAsst
 			}
-			if options.name == "" {
+			if options.assistant == "" {
 				pcio.Printf("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))
 				return
 			}
 
 			chatHistory := state.ChatHist.Get()
-			chat, ok := (*chatHistory.History)[options.name]
+			chat, ok := (*chatHistory.History)[options.assistant]
 			if !ok {
-				pcio.Printf("No chat history found for assistant %s\n", style.Emphasis(options.name))
+				pcio.Printf("No chat history found for assistant %s\n", style.Emphasis(options.assistant))
 				return
 			}
 
@@ -45,7 +45,7 @@ func NewAssistantChatDescribeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant chat to describe")
+	cmd.Flags().StringVarP(&options.assistant, "assistant", "a", "", "name of the assistant chat to describe")
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
 
 	return cmd

--- a/internal/pkg/cli/command/assistant/cmd.go
+++ b/internal/pkg/cli/command/assistant/cmd.go
@@ -25,16 +25,16 @@ func NewAssistantCommand() *cobra.Command {
 	cmd.AddGroup(help.GROUP_ASSISTANT_MANAGEMENT)
 	cmd.AddCommand(NewCreateAssistantCmd())
 	cmd.AddCommand(NewListAssistantsCmd())
-	cmd.AddCommand(NewDescribeAssistantCmd())
 	cmd.AddCommand(NewDeleteAssistantCmd())
 
 	// Assistant Operations
 	cmd.AddGroup(help.GROUP_ASSISTANT_OPERATIONS)
+	cmd.AddCommand(NewDescribeAssistantCmd())
 	cmd.AddCommand(NewAssistantChatCmd())
 	cmd.AddCommand(NewListAssistantFilesCmd())
-	cmd.AddCommand(NewDeleteKnowledgeFileCmd())
+	cmd.AddCommand(NewDeleteAssistantFileCmd())
 	cmd.AddCommand(NewUploadAssistantFileCmd())
-	cmd.AddCommand(NewDescribeKnowledgeFileCmd())
+	cmd.AddCommand(NewDescribeAssistantFileCmd())
 
 	return cmd
 }

--- a/internal/pkg/cli/command/assistant/create.go
+++ b/internal/pkg/cli/command/assistant/create.go
@@ -29,7 +29,7 @@ func NewCreateAssistantCmd() *cobra.Command {
 				msg.FailMsg("Failed to create assistant %s: %s\n", style.Emphasis(options.name), err)
 				exit.Error(err)
 			}
-			msg.SuccessMsg("assistant %s created successfully.\n", style.Emphasis(assistant.Name))
+			msg.SuccessMsg("Assistant %s created successfully.\n", style.Emphasis(assistant.Name))
 
 			if options.json {
 				text.PrettyPrintJSON(assistant)

--- a/internal/pkg/cli/command/assistant/delete.go
+++ b/internal/pkg/cli/command/assistant/delete.go
@@ -2,9 +2,11 @@ package assistant
 
 import (
 	"github.com/pinecone-io/cli/internal/pkg/assistants"
+	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 	"github.com/pinecone-io/cli/internal/pkg/utils/text"
 	"github.com/spf13/cobra"
@@ -29,14 +31,20 @@ func NewDeleteAssistantCmd() *cobra.Command {
 				exit.Error(err)
 			}
 
+			// Deleting targeted assistant, unset target
+			targetAsst := state.TargetAsst.Get()
+			if targetAsst.Name == options.name {
+				state.TargetAsst.Clear()
+				pcio.Printf("Target assistant %s deleted.\n", style.Emphasis(options.name))
+				pcio.Printf("Use %s to set a new target.\n", style.Code("pinecone assistant target"))
+			}
+
 			if options.json {
 				text.PrettyPrintJSON(resp)
 				return
 			}
 
 			msg.SuccessMsg("Assistant %s deleted.\n", style.Emphasis(options.name))
-
-			// TODO - check to see if the current target is the delete assistant, if so we need to clear it
 		},
 	}
 

--- a/internal/pkg/cli/command/assistant/describe.go
+++ b/internal/pkg/cli/command/assistant/describe.go
@@ -23,7 +23,7 @@ func NewDescribeAssistantCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe",
 		Short:   "Describe an assistant",
-		GroupID: help.GROUP_ASSISTANT_MANAGEMENT.ID,
+		GroupID: help.GROUP_ASSISTANT_OPERATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {
 			// If no name is provided, use the target assistant
 			if options.name == "" {
@@ -36,17 +36,17 @@ func NewDescribeAssistantCmd() *cobra.Command {
 				return
 			}
 
-			model, err := assistants.DescribeAssistant(options.name)
+			assistant, err := assistants.DescribeAssistant(options.name)
 			if err != nil {
 				msg.FailMsg("Failed to describe assistant %s: %s\n", style.Emphasis(options.name), err)
 				exit.Error(err)
 			}
 
 			if options.json {
-				text.PrettyPrintJSON(model)
+				text.PrettyPrintJSON(assistant)
 				return
 			} else {
-				presenters.PrintDescribeAssistantTable(model)
+				presenters.PrintDescribeAssistantTable(assistant)
 			}
 
 		},

--- a/internal/pkg/cli/command/assistant/describe.go
+++ b/internal/pkg/cli/command/assistant/describe.go
@@ -27,8 +27,8 @@ func NewDescribeAssistantCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// If no name is provided, use the target assistant
 			if options.name == "" {
-				targetKm := state.TargetAsst.Get().Name
-				options.name = targetKm
+				targetAsst := state.TargetAsst.Get().Name
+				options.name = targetAsst
 			}
 			if options.name == "" {
 				msg.FailMsg("You must target an assistant or specify one to describe with the %s flag\n", style.Emphasis("--name"))

--- a/internal/pkg/cli/command/assistant/file_delete.go
+++ b/internal/pkg/cli/command/assistant/file_delete.go
@@ -11,8 +11,8 @@ import (
 )
 
 type DeleteAssistantFileCmdOptions struct {
-	name   string
-	fileId string
+	assistant string
+	fileId    string
 }
 
 func NewDeleteAssistantFileCmd() *cobra.Command {
@@ -23,18 +23,18 @@ func NewDeleteAssistantFileCmd() *cobra.Command {
 		Short:   "Delete a file in an assistant",
 		GroupID: help.GROUP_ASSISTANT_OPERATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.assistant = targetAsst
 			}
-			if options.name == "" {
+			if options.assistant == "" {
 				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))
 				exit.ErrorMsg("no assistant specified")
 			}
 
-			_, err := assistants.DeleteAssistantFile(options.name, options.fileId)
+			_, err := assistants.DeleteAssistantFile(options.assistant, options.fileId)
 			if err != nil {
-				msg.FailMsg("Failed to delete file %s in assistant %s: %s\n", style.Emphasis(options.fileId), style.Emphasis(options.name), err)
+				msg.FailMsg("Failed to delete file %s in assistant %s: %s\n", style.Emphasis(options.fileId), style.Emphasis(options.assistant), err)
 				exit.Error(err)
 			}
 
@@ -42,7 +42,7 @@ func NewDeleteAssistantFileCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant to list files for")
+	cmd.Flags().StringVarP(&options.assistant, "assistant", "a", "", "name of the assistant to list files for")
 	cmd.Flags().StringVarP(&options.fileId, "id", "i", "", "id of the file to describe")
 	cmd.MarkFlagRequired("id")
 

--- a/internal/pkg/cli/command/assistant/file_delete.go
+++ b/internal/pkg/cli/command/assistant/file_delete.go
@@ -10,13 +10,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type DeleteKnowledgeFileCmdOptions struct {
+type DeleteAssistantFileCmdOptions struct {
 	name   string
 	fileId string
 }
 
-func NewDeleteKnowledgeFileCmd() *cobra.Command {
-	options := DeleteKnowledgeFileCmdOptions{}
+func NewDeleteAssistantFileCmd() *cobra.Command {
+	options := DeleteAssistantFileCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "file-delete",
@@ -28,11 +28,11 @@ func NewDeleteKnowledgeFileCmd() *cobra.Command {
 				options.name = targetKm
 			}
 			if options.name == "" {
-				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--model"))
+				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))
 				exit.ErrorMsg("no assistant specified")
 			}
 
-			_, err := assistants.DeleteKnowledgeFile(options.name, options.fileId)
+			_, err := assistants.DeleteAssistantFile(options.name, options.fileId)
 			if err != nil {
 				msg.FailMsg("Failed to delete file %s in assistant %s: %s\n", style.Emphasis(options.fileId), style.Emphasis(options.name), err)
 				exit.Error(err)
@@ -42,7 +42,7 @@ func NewDeleteKnowledgeFileCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.name, "model", "m", "", "name of the assistant to list files for")
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant to list files for")
 	cmd.Flags().StringVarP(&options.fileId, "id", "i", "", "id of the file to describe")
 	cmd.MarkFlagRequired("id")
 

--- a/internal/pkg/cli/command/assistant/file_describe.go
+++ b/internal/pkg/cli/command/assistant/file_describe.go
@@ -13,14 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type DescribeKnowledgeFileCmdOptions struct {
+type DescribeAssistantFileCmdOptions struct {
 	name   string
 	fileId string
 	json   bool
 }
 
-func NewDescribeKnowledgeFileCmd() *cobra.Command {
-	options := DescribeKnowledgeFileCmdOptions{}
+func NewDescribeAssistantFileCmd() *cobra.Command {
+	options := DescribeAssistantFileCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "file-describe",
@@ -32,7 +32,7 @@ func NewDescribeKnowledgeFileCmd() *cobra.Command {
 				options.name = targetKm
 			}
 			if options.name == "" {
-				pcio.Printf("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--model"))
+				pcio.Printf("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))
 				return
 			}
 
@@ -51,7 +51,7 @@ func NewDescribeKnowledgeFileCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "model", "m", "", "name of the assistant to list files for")
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant to list files for")
 	cmd.Flags().StringVarP(&options.fileId, "id", "i", "", "id of the file to describe")
 	cmd.MarkFlagRequired("id")
 

--- a/internal/pkg/cli/command/assistant/file_describe.go
+++ b/internal/pkg/cli/command/assistant/file_describe.go
@@ -14,9 +14,9 @@ import (
 )
 
 type DescribeAssistantFileCmdOptions struct {
-	name   string
-	fileId string
-	json   bool
+	assistant string
+	fileId    string
+	json      bool
 }
 
 func NewDescribeAssistantFileCmd() *cobra.Command {
@@ -27,16 +27,16 @@ func NewDescribeAssistantFileCmd() *cobra.Command {
 		Short:   "Describe a file in an assistant",
 		GroupID: help.GROUP_ASSISTANT_OPERATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.assistant = targetAsst
 			}
-			if options.name == "" {
+			if options.assistant == "" {
 				pcio.Printf("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--name"))
 				return
 			}
 
-			file, err := assistants.DescribeAssistantFile(options.name, options.fileId)
+			file, err := assistants.DescribeAssistantFile(options.assistant, options.fileId)
 			if err != nil {
 				msg.FailMsg("Failed to describe file %s in assistant: %s\n", style.Emphasis(options.fileId), err)
 				exit.Error(err)
@@ -51,7 +51,7 @@ func NewDescribeAssistantFileCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant to list files for")
+	cmd.Flags().StringVarP(&options.assistant, "assistant", "a", "", "name of the assistant to list files for")
 	cmd.Flags().StringVarP(&options.fileId, "id", "i", "", "id of the file to describe")
 	cmd.MarkFlagRequired("id")
 

--- a/internal/pkg/cli/command/assistant/file_upload.go
+++ b/internal/pkg/cli/command/assistant/file_upload.go
@@ -32,7 +32,7 @@ func NewUploadAssistantFileCmd() *cobra.Command {
 				options.name = targetKm
 			}
 			if options.name == "" {
-				msg.FailMsg("You must target a assistant or specify one with the %s flag\n", style.Emphasis("--model"))
+				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--assistant"))
 				exit.Error(fmt.Errorf("no assistant specified"))
 			}
 
@@ -52,7 +52,7 @@ func NewUploadAssistantFileCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "model", "m", "", "name of the assistant to upload a file to")
+	cmd.Flags().StringVarP(&options.name, "assistant", "a", "", "name of the assistant to upload a file to")
 	cmd.Flags().StringVarP(&options.filePath, "file", "f", "", "the path of the file you want to upload")
 	cmd.MarkFlagRequired("file")
 

--- a/internal/pkg/cli/command/assistant/file_upload.go
+++ b/internal/pkg/cli/command/assistant/file_upload.go
@@ -14,9 +14,9 @@ import (
 )
 
 type UploadAssistantCmdOptions struct {
-	name     string
-	filePath string
-	json     bool
+	assistant string
+	filePath  string
+	json      bool
 }
 
 func NewUploadAssistantFileCmd() *cobra.Command {
@@ -27,18 +27,18 @@ func NewUploadAssistantFileCmd() *cobra.Command {
 		Short:   "Upload a file to an assistant",
 		GroupID: help.GROUP_ASSISTANT_OPERATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.assistant = targetAsst
 			}
-			if options.name == "" {
+			if options.assistant == "" {
 				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--assistant"))
 				exit.Error(fmt.Errorf("no assistant specified"))
 			}
 
-			file, err := assistants.UploadAssistantFile(options.name, options.filePath)
+			file, err := assistants.UploadAssistantFile(options.assistant, options.filePath)
 			if err != nil {
-				msg.FailMsg("Failed to upload file %s to assistant %s: %s\n", style.Emphasis(options.filePath), style.Emphasis(options.name), err)
+				msg.FailMsg("Failed to upload file %s to assistant %s: %s\n", style.Emphasis(options.filePath), style.Emphasis(options.assistant), err)
 				exit.Error(err)
 			}
 
@@ -52,7 +52,7 @@ func NewUploadAssistantFileCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "assistant", "a", "", "name of the assistant to upload a file to")
+	cmd.Flags().StringVarP(&options.assistant, "assistant", "a", "", "name of the assistant to upload a file to")
 	cmd.Flags().StringVarP(&options.filePath, "file", "f", "", "the path of the file you want to upload")
 	cmd.MarkFlagRequired("file")
 

--- a/internal/pkg/cli/command/assistant/files_list.go
+++ b/internal/pkg/cli/command/assistant/files_list.go
@@ -17,13 +17,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ListKnowledgeFilesCmdOptions struct {
+type ListAssistantFilesCmdOptions struct {
 	json bool
 	name string
 }
 
 func NewListAssistantFilesCmd() *cobra.Command {
-	options := ListKnowledgeFilesCmdOptions{}
+	options := ListAssistantFilesCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "files",
@@ -35,7 +35,7 @@ func NewListAssistantFilesCmd() *cobra.Command {
 				options.name = targetKm
 			}
 			if options.name == "" {
-				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--model"))
+				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--assistant"))
 				exit.Error(fmt.Errorf("no assistant specified"))
 			}
 
@@ -61,7 +61,7 @@ func NewListAssistantFilesCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "model", "m", "", "name of the assistant to list files for")
+	cmd.Flags().StringVarP(&options.name, "assistant", "a", "", "name of the assistant to list files for")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/assistant/files_list.go
+++ b/internal/pkg/cli/command/assistant/files_list.go
@@ -18,8 +18,8 @@ import (
 )
 
 type ListAssistantFilesCmdOptions struct {
-	json bool
-	name string
+	assistant string
+	json      bool
 }
 
 func NewListAssistantFilesCmd() *cobra.Command {
@@ -30,18 +30,18 @@ func NewListAssistantFilesCmd() *cobra.Command {
 		Short:   "See the list of files in an assistant",
 		GroupID: help.GROUP_ASSISTANT_OPERATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			targetKm := state.TargetAsst.Get().Name
-			if targetKm != "" {
-				options.name = targetKm
+			targetAsst := state.TargetAsst.Get().Name
+			if targetAsst != "" {
+				options.assistant = targetAsst
 			}
-			if options.name == "" {
+			if options.assistant == "" {
 				msg.FailMsg("You must target an assistant or specify one with the %s flag\n", style.Emphasis("--assistant"))
 				exit.Error(fmt.Errorf("no assistant specified"))
 			}
 
-			fileList, err := assistants.ListAssistantFiles(options.name)
+			fileList, err := assistants.ListAssistantFiles(options.assistant)
 			if err != nil {
-				msg.FailMsg("Failed to list files for assistant %s: %s\n", style.Emphasis(options.name), err)
+				msg.FailMsg("Failed to list files for assistant %s: %s\n", style.Emphasis(options.assistant), err)
 				exit.Error(err)
 			}
 
@@ -52,7 +52,7 @@ func NewListAssistantFilesCmd() *cobra.Command {
 
 			fileCount := len(fileList.Files)
 			if fileCount == 0 {
-				msg.InfoMsg("No files found in assistant %s. Add one with %s.\n", style.Emphasis(options.name), style.Code("pinecone assistant file-upload"))
+				msg.InfoMsg("No files found in assistant %s. Add one with %s.\n", style.Emphasis(options.assistant), style.Code("pinecone assistant file-upload"))
 				return
 			}
 
@@ -60,8 +60,8 @@ func NewListAssistantFilesCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&options.assistant, "assistant", "a", "", "name of the assistant to list files for")
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().StringVarP(&options.name, "assistant", "a", "", "name of the assistant to list files for")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/assistant/list.go
+++ b/internal/pkg/cli/command/assistant/list.go
@@ -15,35 +15,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ListKnowledgeModelsCmdOptions struct {
+type ListAssistantsCmdOptions struct {
 	json bool
 }
 
 func NewListAssistantsCmd() *cobra.Command {
-	options := ListKnowledgeModelsCmdOptions{}
+	options := ListAssistantsCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "See the list of assistants in the targeted project",
 		GroupID: help.GROUP_ASSISTANT_MANAGEMENT.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			modelList, err := assistants.ListAssistants()
+			assistantList, err := assistants.ListAssistants()
 			if err != nil {
 				exit.Error(err)
 			}
 
 			if options.json {
-				text.PrettyPrintJSON(modelList)
+				text.PrettyPrintJSON(assistantList)
 				return
 			}
 
-			modelCount := len(modelList.Assistants)
+			modelCount := len(assistantList.Assistants)
 			if modelCount == 0 {
 				msg.InfoMsg("No assistants found. Create one with %s.\n", style.Code("pinecone assistant create"))
 				return
 			}
 
-			printTableModels(modelList.Assistants)
+			printTableAssistants(assistantList.Assistants)
 		},
 	}
 
@@ -52,14 +52,14 @@ func NewListAssistantsCmd() *cobra.Command {
 	return cmd
 }
 
-func printTableModels(models []assistants.AssistantModel) {
+func printTableAssistants(assistants []assistants.AssistantModel) {
 	writer := tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
 
 	columns := []string{"NAME", "METADATA", "STATUS", "CREATED_AT", "UPDATED_AT"}
 	header := strings.Join(columns, "\t") + "\n"
 	pcio.Fprint(writer, header)
 
-	for _, model := range models {
+	for _, model := range assistants {
 		values := []string{model.Name, model.Metadata.ToString(), string(model.Status), model.CreatedAt, model.UpdatedAt}
 		pcio.Fprintf(writer, strings.Join(values, "\t")+"\n")
 	}

--- a/internal/pkg/cli/command/assistant/target.go
+++ b/internal/pkg/cli/command/assistant/target.go
@@ -30,10 +30,10 @@ type AssistantTargetCmdOptions struct {
 	json  bool
 }
 
-var kmTargetHelpPart1 string = text.WordWrap(`There are many assistant commands which target a specific
+var asstTargetHelpPart1 string = text.WordWrap(`There are many assistant commands which target a specific
 assistant. This command allows you to set and clear the target assistant for performing operations.`, 80)
 
-var targetHelp = pcio.Sprintf("%s\n", kmTargetHelpPart1)
+var targetHelp = pcio.Sprintf("%s\n", asstTargetHelpPart1)
 
 func NewAssistantTargetCmd() *cobra.Command {
 	options := AssistantTargetCmdOptions{}
@@ -150,7 +150,7 @@ func printTarget(useJson bool) {
 }
 
 func uiModelSelector(availableAssistants []string) string {
-	var targetModel string = ""
+	var targetAssistant string = ""
 	prompt := "Choose an assistant to target"
 	listHeight := len(availableAssistants) + 4
 	onQuit := func() {
@@ -158,7 +158,7 @@ func uiModelSelector(availableAssistants []string) string {
 		pcio.Printf("You can always run %s to change assistant context later.\n", style.Code("pinecone assistant target"))
 	}
 	onChoice := func(choice string) string {
-		targetModel = choice
+		targetAssistant = choice
 		return "Target assistant: " + choice
 	}
 	m2 := NewList(availableAssistants, listHeight, prompt, onQuit, onChoice)
@@ -166,7 +166,7 @@ func uiModelSelector(availableAssistants []string) string {
 		pcio.Println("Error selecting assistant:", err)
 		exit.Error(err)
 	}
-	return targetModel
+	return targetAssistant
 }
 
 type ListModel struct {

--- a/internal/pkg/cli/command/assistant/target.go
+++ b/internal/pkg/cli/command/assistant/target.go
@@ -24,10 +24,10 @@ import (
 )
 
 type AssistantTargetCmdOptions struct {
-	name        string
-	json        bool
-	clear       bool
-	interactive bool
+	name  string
+	clear bool
+	show  bool
+	json  bool
 }
 
 var kmTargetHelpPart1 string = text.WordWrap(`There are many assistant commands which target a specific
@@ -67,64 +67,57 @@ func NewAssistantTargetCmd() *cobra.Command {
 				return
 			}
 
-			// TODO - move this into a show flag, allow interactive selection
-			// Print current target if no assistant is specified
-			if options.name == "" && !options.interactive {
+			// Print current target
+			if options.show {
 				printTarget(options.json)
 				return
 			}
 
-			// If model is specified, set target
-			modelList, err := assistants.ListAssistants()
+			assistantList, err := assistants.ListAssistants()
 			if err != nil {
 				msg.FailMsg("An error occured while attempting to fetch a list of assistants: %s\n", err)
 				exit.Error(err)
 			}
+
+			// If an assistant is specified, try to set target
 			if options.name != "" {
-				// Check if model exists
-				modelExists := false
-				for _, model := range modelList.Assistants {
+				assistantExists := false
+				for _, model := range assistantList.Assistants {
 					if model.Name == options.name {
-						modelExists = true
+						assistantExists = true
 						break
 					}
 				}
 
-				if !modelExists {
-					availableModels := make([]string, len(modelList.Assistants))
-					for i, model := range modelList.Assistants {
-						availableModels[i] = fmt.Sprintf("'%s'", model.Name)
+				if !assistantExists {
+					availableAssistants := make([]string, len(assistantList.Assistants))
+					for i, model := range assistantList.Assistants {
+						availableAssistants[i] = fmt.Sprintf("'%s'", model.Name)
 					}
-					sort.Strings(availableModels)
-					availableModelsStr := fmt.Sprintf("[%s]", strings.Join(availableModels, ", "))
+					sort.Strings(availableAssistants)
+					availableAssistantsStr := fmt.Sprintf("[%s]", strings.Join(availableAssistants, ", "))
 
-					msg.FailMsg("Assistant %s not found. Available models: %s\n", style.Emphasis(options.name), style.Emphasis(availableModelsStr))
+					msg.FailMsg("Assistant %s not found. Available assistants: %s\n", style.Emphasis(options.name), style.Emphasis(availableAssistantsStr))
 					exit.ErrorMsg("assistant not found")
 					return
 				}
 
 				state.TargetAsst.Set(&state.TargetAssistant{Name: options.name})
 
-				if !options.json {
-					msg.SuccessMsg("Target assistant set to %s\n", style.Emphasis(options.name))
-				}
+				msg.SuccessMsg("Target assistant set to %s\n", style.Emphasis(options.name))
 				printTarget(options.json)
 				return
 			}
 
-			if options.interactive {
-				if len(modelList.Assistants) == 0 {
-					msg.InfoMsg("No assistants found. Create one with %s.\n", style.Code("pinecone assistant create"))
-					exit.ErrorMsg("no assistants found")
+			// If no assistant is specified and the user has assistants, allow them to select one interactively
+			if len(assistantList.Assistants) > 0 {
+				assistantNames := make([]string, len(assistantList.Assistants))
+				for i, model := range assistantList.Assistants {
+					assistantNames[i] = model.Name
 				}
+				sort.Strings(assistantNames)
 
-				modelNames := make([]string, len(modelList.Assistants))
-				for i, model := range modelList.Assistants {
-					modelNames[i] = model.Name
-				}
-				sort.Strings(modelNames)
-
-				selectedModel := uiModelSelector(modelNames)
+				selectedModel := uiModelSelector(assistantNames)
 				if selectedModel == "" {
 					// User interrupted selector with ctrl+c
 					exit.Success()
@@ -134,16 +127,16 @@ func NewAssistantTargetCmd() *cobra.Command {
 				msg.SuccessMsg("Target assistant set to %s\n", style.Emphasis(selectedModel))
 				printTarget(options.json)
 			} else {
-				msg.FailMsg("You must specify an assistant with %s or use the %s flag to choose one interactively\n", style.Code("--model"), style.Code("-i"))
-				exit.ErrorMsg("no assistant specified")
+				msg.InfoMsg("No assistants found. Create one with %s.\n", style.Code("pinecone assistant create"))
+				exit.ErrorMsg("no assistants found")
 			}
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.name, "model", "m", "", "name of the assistant to target")
-	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
-	cmd.Flags().BoolVarP(&options.interactive, "interactive", "i", false, "choose a model interactively")
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the assistant to target")
+	cmd.Flags().BoolVarP(&options.show, "show", "s", false, "show which assistant is currently targeted")
 	cmd.Flags().BoolVar(&options.clear, "clear", false, "clear the target assistant")
+	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
 
 	return cmd
 }
@@ -153,22 +146,22 @@ func printTarget(useJson bool) {
 		text.PrettyPrintJSON(state.GetTargetContext())
 		return
 	}
-	presenters.PrintTargetKnowledgeModel(state.GetTargetContext())
+	presenters.PrintTargetAssistant(state.GetTargetContext())
 }
 
-func uiModelSelector(availableModels []string) string {
+func uiModelSelector(availableAssistants []string) string {
 	var targetModel string = ""
 	prompt := "Choose an assistant to target"
-	listHeight := len(availableModels) + 4
+	listHeight := len(availableAssistants) + 4
 	onQuit := func() {
 		pcio.Println("Exiting without targeting an assistant.")
-		pcio.Printf("You can always run %s to change assistant context later.\n", style.Code("pinecone assistant target -i"))
+		pcio.Printf("You can always run %s to change assistant context later.\n", style.Code("pinecone assistant target"))
 	}
 	onChoice := func(choice string) string {
 		targetModel = choice
 		return "Target assistant: " + choice
 	}
-	m2 := NewList(availableModels, listHeight, prompt, onQuit, onChoice)
+	m2 := NewList(availableAssistants, listHeight, prompt, onQuit, onChoice)
 	if _, err := tea.NewProgram(m2).Run(); err != nil {
 		pcio.Println("Error selecting assistant:", err)
 		exit.Error(err)

--- a/internal/pkg/cli/command/config/set_env.go
+++ b/internal/pkg/cli/command/config/set_env.go
@@ -69,7 +69,7 @@ func NewSetEnvCmd() *cobra.Command {
 
 			if state.TargetAsst.Get().Name != "" {
 				state.TargetAsst.Clear()
-				msg.InfoMsg("Target assistant cleared; to set a new target assistant, run %s", style.Code("pinecone assistant target -m myassistant"))
+				msg.InfoMsg("Target assistant cleared; to set a new target assistant, run %s", style.Code("pinecone assistant target -n myassistant"))
 			}
 		},
 	}

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -67,7 +67,7 @@ func NewTargetCmd() *cobra.Command {
 				return
 			}
 
-			// Print current target if no org, project, or knowledge model is specified
+			// Print current target if show is set
 			if options.show {
 				if options.json {
 					log.Info().Msg("Outputting target context as JSON")

--- a/internal/pkg/utils/configuration/state/state.go
+++ b/internal/pkg/utils/configuration/state/state.go
@@ -45,7 +45,7 @@ var (
 		},
 	}
 	TargetAsst = configuration.MarshaledProperty[TargetAssistant]{
-		KeyName:    "target_knowledge_model",
+		KeyName:    "target_assistant",
 		ViperStore: StateViper,
 		DefaultValue: &TargetAssistant{
 			Name: "",

--- a/internal/pkg/utils/presenters/target_context.go
+++ b/internal/pkg/utils/presenters/target_context.go
@@ -33,7 +33,7 @@ func PrintTargetContext(context *state.TargetContext) {
 	writer.Flush()
 }
 
-func PrintTargetKnowledgeModel(context *state.TargetContext) {
+func PrintTargetAssistant(context *state.TargetContext) {
 	log.Info().
 		Str("assistant", context.Assistant).
 		Msg("Printing target assistant")

--- a/internal/pkg/utils/sdk/client.go
+++ b/internal/pkg/utils/sdk/client.go
@@ -103,7 +103,7 @@ func NewPineconeClientForUser(projectId string) *pinecone.Client {
 
 func NewClientForMachine(apiKey string) *pinecone.Client {
 	if apiKey == "" {
-		exit.Error(pcio.Errorf("API key not set. Please run %s", style.Code("pinecone auth set-api-key")))
+		exit.Error(pcio.Errorf("API key not set. Please run %s", style.Code("pinecone config set-api-key")))
 	}
 
 	pc, err := pinecone.NewClient(newClientParams(apiKey))
@@ -141,7 +141,7 @@ func NewPineconeClientForProjectById(orgId string, projectId string) *pinecone.C
 	}
 
 	if key == "" {
-		msg.FailMsg("API key not set. Please run %s", style.Code("pinecone auth login"))
+		msg.FailMsg("API key not set. Please run %s or %s", style.Code("pinecone login"), style.Code("pinecone config set-api-key"))
 		exit.Error(pcio.Errorf("API key not set."))
 	}
 


### PR DESCRIPTION
## Problem
There's still additional naming cleanup to be done. We also want to change the behavior for the `assistant` command to allow interactive selection of available assistants when no arguments are passed.

## Solution

- Allow interactive targeting of assistants when no flags are passed.
- Properly clear `TargetedAsst` state when a user deletes an assistant that's the current target.
- Reorganize the `assistant` sub-commands.
- Clean up variables and function names to follow new naming paradigm.
- Additional cleanup / chores.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
