### PR TITLE
Streaming Chat Completions

### DIFF
--- a/internal/pkg/assistants/assistant_file_upload.go
+++ b/internal/pkg/assistants/assistant_file_upload.go
@@ -16,7 +16,7 @@ func UploadAssistantFile(name string, filePath string) (*AssistantFileModel, err
 		return nil, err
 	}
 
-	resp, err := network.PostAndDecodeMultipartFormData[AssistantFileModel](
+	resp, err := network.PostMultipartFormDataAndDecode[AssistantFileModel](
 		assistantDataUrl,
 		fmt.Sprintf(URL_ASSISTANT_FILE_UPLOAD, name),
 		true,

--- a/internal/pkg/utils/models/models.go
+++ b/internal/pkg/utils/models/models.go
@@ -3,6 +3,7 @@ package models
 import "time"
 
 type ChatCompletionRequest struct {
+	Stream   bool                    `json:"stream"`
 	Messages []ChatCompletionMessage `json:"messages"`
 }
 
@@ -10,6 +11,12 @@ type ChatCompletionModel struct {
 	Id      string        `json:"id"`
 	Choices []ChoiceModel `json:"choices"`
 	Model   string        `json:"model"`
+}
+
+type ChoiceModel struct {
+	FinishReason ChatFinishReason      `json:"finish_reason"`
+	Index        int32                 `json:"index"`
+	Message      ChatCompletionMessage `json:"message"`
 }
 
 type ChatCompletionMessage struct {
@@ -33,8 +40,26 @@ const (
 	FunctionCall  ChatFinishReason = "function_call"
 )
 
-type ChoiceModel struct {
+type StreamChatCompletionModel struct {
+	Id      string             `json:"id"`
+	Choices []ChoiceChunkModel `json:"choices"`
+	Model   string             `json:"model"`
+}
+
+type StreamChunk struct {
+	Data StreamChatCompletionModel `json:"data"`
+}
+
+type ChoiceChunkModel struct {
 	FinishReason ChatFinishReason      `json:"finish_reason"`
 	Index        int32                 `json:"index"`
-	Message      ChatCompletionMessage `json:"message"`
+	Delta        ChatCompletionMessage `json:"delta"`
+}
+
+type ContextRefModel struct {
+	Id     string   `json:"id"`
+	Source string   `json:"source"`
+	Text   string   `json:"text"`
+	Score  float64  `json:"score"`
+	Path   []string `json:"path"`
 }

--- a/internal/pkg/utils/network/request.go
+++ b/internal/pkg/utils/network/request.go
@@ -85,6 +85,45 @@ func decodeResponse[T any](resp *http.Response, target *T) error {
 	return nil
 }
 
+func RequestWithBody[B any](baseUrl string, path string, method string, useApiKey bool, body B) (*http.Response, error) {
+	url := baseUrl + path
+
+	var bodyJson []byte
+	bodyJson, err := json.Marshal(body)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("method", method).
+			Str("url", url).
+			Msg("Error marshalling JSON")
+		return nil, pcio.Errorf("error marshalling JSON: %v", err)
+	}
+
+	req, err := buildRequest(method, url, bodyJson)
+	log.Info().
+		Str("method", method).
+		Str("url", url).
+		Msg("Fetching data from dashboard")
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("url", url).
+			Str("method", method).
+			Msg("Error building request")
+		return nil, pcio.Errorf("error building request: %v", err)
+	}
+
+	resp, err := performRequest(req, useApiKey)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("method", method).
+			Str("url", url)
+		return nil, pcio.Errorf("error performing request to %s: %v", url, err)
+	}
+	return resp, nil
+}
+
 func RequestWithBodyAndDecode[B any, R any](baseUrl string, path string, method string, useApiKey bool, body B) (*R, error) {
 	url := baseUrl + path
 


### PR DESCRIPTION
## Problem
The `chat/completions` endpoint now supports a boolean allowing streaming. The server returns a `text/event-stream` that we need to parse and render.

## Solution
- Add new `PostAndStreamChatResponse` function to `request_post.go` which handles sending the initial post, and using a `bufio.Scanner` parses each chunk into `StreamChatCompletionModel`. We then print to console and concatenate the string for storage.
- Entering interactive chat via `pinecone assistant chat` will default to enabling streaming, otherwise you can pass `--stream` to have the response streamed back rather than waiting for the complete payload.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Send messages or enter chat mode using `assistant`.
