### PR TITLE
Format streaming chat response, fix `file-upload` via `login` auth

### DIFF
--- a/internal/pkg/utils/network/request.go
+++ b/internal/pkg/utils/network/request.go
@@ -100,19 +100,18 @@ func decodeResponse[T any](resp *http.Response, target *T) error {
 func RequestWithBody[B any](baseUrl string, path string, method string, body B) (*http.Response, error) {
 	url := baseUrl + path
 
-	var bodyJson []byte
-	bodyJson, err := json.Marshal(body)
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("method", method).
 			Str("url", url).
-			Msg("Error marshalling JSON")
+			Msg("Error encoding body")
 		return nil, pcio.Errorf("error marshalling JSON: %v", err)
 	}
-	bodyBuffer := bytes.NewBuffer(bodyJson)
 
-	req, err := buildRequest(method, url, bodyBuffer)
+	req, err := buildRequest(method, url, &buf)
 	log.Info().
 		Str("method", method).
 		Str("url", url).
@@ -140,19 +139,18 @@ func RequestWithBody[B any](baseUrl string, path string, method string, body B) 
 func RequestWithBodyAndDecode[B any, R any](baseUrl string, path string, method string, body B) (*R, error) {
 	url := baseUrl + path
 
-	var bodyJson []byte
-	bodyJson, err := json.Marshal(body)
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("method", method).
 			Str("url", url).
-			Msg("Error marshalling JSON")
+			Msg("Error encoding body")
 		return nil, pcio.Errorf("error marshalling JSON: %v", err)
 	}
-	bodyBuffer := bytes.NewBuffer(bodyJson)
 
-	req, err := buildRequest(method, url, bodyBuffer)
+	req, err := buildRequest(method, url, &buf)
 	log.Info().
 		Str("method", method).
 		Str("url", url).

--- a/internal/pkg/utils/network/request.go
+++ b/internal/pkg/utils/network/request.go
@@ -18,11 +18,8 @@ import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
-func buildRequest(verb string, path string, bodyJson []byte) (*http.Request, error) {
-	var body *bytes.Buffer
-	if len(bodyJson) > 0 {
-		body = bytes.NewBuffer(bodyJson)
-	} else {
+func buildRequest(verb string, path string, body *bytes.Buffer) (*http.Request, error) {
+	if body == nil {
 		body = bytes.NewBuffer([]byte{})
 	}
 
@@ -113,8 +110,9 @@ func RequestWithBody[B any](baseUrl string, path string, method string, body B) 
 			Msg("Error marshalling JSON")
 		return nil, pcio.Errorf("error marshalling JSON: %v", err)
 	}
+	bodyBuffer := bytes.NewBuffer(bodyJson)
 
-	req, err := buildRequest(method, url, bodyJson)
+	req, err := buildRequest(method, url, bodyBuffer)
 	log.Info().
 		Str("method", method).
 		Str("url", url).
@@ -152,8 +150,9 @@ func RequestWithBodyAndDecode[B any, R any](baseUrl string, path string, method 
 			Msg("Error marshalling JSON")
 		return nil, pcio.Errorf("error marshalling JSON: %v", err)
 	}
+	bodyBuffer := bytes.NewBuffer(bodyJson)
 
-	req, err := buildRequest(method, url, bodyJson)
+	req, err := buildRequest(method, url, bodyBuffer)
 	log.Info().
 		Str("method", method).
 		Str("url", url).

--- a/internal/pkg/utils/network/request_post.go
+++ b/internal/pkg/utils/network/request_post.go
@@ -42,12 +42,12 @@ func PostMultipartFormDataAndDecode[R any](baseUrl string, path string, bodyPath
 		return nil, pcio.Errorf("error closing writer: %v", err)
 	}
 
-	// Override Content-Type to support multipart/form-data
 	req, err := buildRequest(http.MethodPost, url, &requestBody)
 	if err != nil {
 		return nil, pcio.Errorf("error building request: %v", err)
 	}
 
+	// Override Content-Type to support multipart/form-data
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	log.Info().

--- a/internal/pkg/utils/network/request_post.go
+++ b/internal/pkg/utils/network/request_post.go
@@ -42,9 +42,10 @@ func PostMultipartFormDataAndDecode[R any](baseUrl string, path string, bodyPath
 		return nil, pcio.Errorf("error closing writer: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", url, &requestBody)
+	// Override Content-Type to support multipart/form-data
+	req, err := buildRequest(http.MethodPost, url, &requestBody)
 	if err != nil {
-		return nil, pcio.Errorf("error creating request: %v", err)
+		return nil, pcio.Errorf("error building request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())


### PR DESCRIPTION
## Problem
When we're streaming a chat response and printing the results to the console, we're not word-wrapping or doing any kind of formatting. Also, when trying to upload a file using the `login` OAuth flow calls are rejected due to `401 Unauthorized`.

## Solution
- Add dynamic word-wrapping at 80 characters for streamed chat responses. We can adjust as needed but for now it keeps things far more readable and matches the wrapping we use when printing chat history.
- Update `PostMultipartFormDataAndDecode` to use `buildRequest`, and allow `buildRequest` to take in a `*bytes.buffer` as body rather than `[]byte`.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Test uploading a file to an assistant, and streaming chat responses.
