### PR TITLE
Bump dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/fatih/color v1.16.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/pinecone-io/go-pinecone/v4 v4.1.0
+	github.com/pinecone-io/go-pinecone/v4 v4.1.1
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQ
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/pinecone-io/go-pinecone/v4 v4.1.0 h1:Pl7CGYrbqmDnxag/ZPedzrBDq+xvDpzziByRjCcmvRY=
-github.com/pinecone-io/go-pinecone/v4 v4.1.0/go.mod h1:bLU4DLM79YPfaVLOj23yBPsIohnZDIuUmnTsQXWHzSg=
+github.com/pinecone-io/go-pinecone/v4 v4.1.1 h1:htSmGPf+rKeMtaYNaaC7zLps2jjMOvBz+S/Mq9yQ01g=
+github.com/pinecone-io/go-pinecone/v4 v4.1.1/go.mod h1:bLU4DLM79YPfaVLOj23yBPsIohnZDIuUmnTsQXWHzSg=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=


### PR DESCRIPTION
## Problem
We need to bump to the latest version of go-pinecone to pull in the admin changes. Additionally, there are a few dependabot PRs open around dependencies, and we can get rid of one of them.

## Solution
```
go get -u github.com/pinecone-io/go-pinecone/v4/pinecone@latest
go get github.com/golang-jwt/jwt/v5@v5.2.2
go mod tidy
```

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Make sure CI passes.
