### PR TITLE
Minor DX improvements for contributors

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ universal_binaries:
   - replace: true
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -42,7 +42,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 report_sizes: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 2. Install goreleaser
 
 ```
-brew install goreleaser/tap/goreleaser
+brew install --cask goreleaser
 ```
 
 3. Build the CLI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ brew install --cask goreleaser
 goreleaser build --single-target --snapshot --clean
 ```
 
+## Manual testing
+
 For manual testing in development, you can run commands like this
 
 ```shell
@@ -26,38 +28,68 @@ For manual testing in development, you can run commands like this
 # etc
 ```
 
+**Note:** The actual folder names in `./dist/` may differ from what's shown above. Modern GoReleaser versions create folders like `pc_darwin_all` (universal binary) and `pc_darwin_arm64_v8.0` (architecture-specific). The `pcdev` script handles this automatically.
+
+### Using the `pcdev` script (Recommended)
+
+For easier development testing, you can use the `pcdev` script which automatically detects your OS and runs the correct binary:
+
+```shell
+# Make the script executable (first time only)
+chmod +x pcdev
+
+# Run any pc command
+./pcdev --help
+./pcdev login
+./pcdev index list
+./pcdev version
+```
+
+The script works on:
+
+- **macOS**: Uses the universal binary (`pc_darwin_all`) when available, falls back to architecture-specific binaries
+- **Linux**: Detects architecture and uses the appropriate binary
+- **Windows**: Works in Git Bash, MSYS2, Cygwin, and WSL. For PowerShell, use `pcdev.ps1`
+
+**Windows PowerShell users:**
+
+```powershell
+.\pcdev.ps1 --help
+.\pcdev.ps1 login
+```
+
 ## Usage
 
 ```shell
 # See help
-./dist/pc_darwin_arm64/pc --help
+./pcdev --help
 
 # Set authorization credentials - set an API key directly, or log in via the OAuth flow
-./dist/pc_darwin_arm64/pc config set-api-key
-./dist/pc_darwin_arm64/pc login
+./pcdev config set-api-key
+./pcdev login
 
 # Check currently configured API key
-./dist/pc_darwin_arm64/pc config get-api-key
+./pcdev config get-api-key
 
 # Do index operations
-./dist/pc_darwin_arm64/pc index --help
+./pcdev index --help
 
 # Create serverless indexes.
-./dist/pc_darwin_arm64/pc index create-serverless --help
-./dist/pc_darwin_arm64/pc index create-serverless --name example-index --dimension 1536 --metric cosine --cloud aws --region us-west-2
-./dist/pc_darwin_arm64/pc index create-serverless --name="example-index" --dimension=1536 --metric="cosine" --cloud="aws" --region="us-west-2"
-./dist/pc_darwin_arm64/pc index create-serverless -n example-index -d 1536 -m cosine -c aws -r us-west-2
+./pcdev index create-serverless --help
+./pcdev index create-serverless --name example-index --dimension 1536 --metric cosine --cloud aws --region us-west-2
+./pcdev index create-serverless --name="example-index" --dimension=1536 --metric="cosine" --cloud="aws" --region="us-west-2"
+./pcdev index create-serverless -n example-index -d 1536 -m cosine -c aws -r us-west-2
 
 # Describe index
-./dist/pc_darwin_arm64/pc index describe --name "example-index"
-./dist/pc_darwin_arm64/pc index describe --name "example-index" --json
+./pcdev index describe --name "example-index"
+./pcdev index describe --name "example-index" --json
 
 # List indexes
-./dist/pc_darwin_arm64/pc index list
-./dist/pc_darwin_arm64/pc index list --json
+./pcdev index list
+./pcdev index list --json
 
 # Delete index
-./dist/pc_darwin_arm64/pc index delete --name "example-index"
+./pcdev index delete --name "example-index"
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ We have pre-built binaries for many platforms available on the [Releases](https:
 
 To learn about the steps involved in building from source, see [CONTRIBUTING](./CONTRIBUTING.md)
 
+For contributors, we also provide a `pcdev` script that automatically detects your OS and runs the correct development binary. See the [CONTRIBUTING](./CONTRIBUTING.md) guide for details.
+
 ## Usage
 
 In order to use the Pinecone CLI you will need to authenticate with Pinecone services. This can be done either with an API key, or using the `pc login` flow to authenticate with a Pinecone account via your browser.

--- a/pcdev
+++ b/pcdev
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# pcdev - Development script to run the Pinecone CLI from dist folder
+# Automatically detects OS and architecture to run the correct binary
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[pcdev]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[pcdev]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[pcdev]${NC} $1"
+}
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$SCRIPT_DIR/dist"
+
+# Check if dist directory exists
+if [ ! -d "$DIST_DIR" ]; then
+    print_error "dist directory not found. Please run 'goreleaser build --single-target --snapshot --clean' first."
+    exit 1
+fi
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+print_status "Detected OS: $OS, Architecture: $ARCH"
+
+# Determine the correct binary path
+BINARY_PATH=""
+
+case "$OS" in
+    "darwin")
+        # On macOS, prefer the universal binary if available
+        if [ -f "$DIST_DIR/pc_darwin_all/pc" ]; then
+            BINARY_PATH="$DIST_DIR/pc_darwin_all/pc"
+            print_status "Using universal binary (works on both Intel and Apple Silicon)"
+        elif [ -f "$DIST_DIR/pc_darwin_arm64_v8.0/pc" ]; then
+            BINARY_PATH="$DIST_DIR/pc_darwin_arm64_v8.0/pc"
+            print_status "Using ARM64 binary"
+        elif [ -f "$DIST_DIR/pc_darwin_amd64/pc" ]; then
+            BINARY_PATH="$DIST_DIR/pc_darwin_amd64/pc"
+            print_status "Using AMD64 binary"
+        else
+            print_error "No suitable macOS binary found in dist directory"
+            print_status "Available binaries:"
+            ls -la "$DIST_DIR"/*/pc 2>/dev/null || echo "No binaries found"
+            exit 1
+        fi
+        ;;
+    "linux")
+        case "$ARCH" in
+            "x86_64"|"amd64")
+                if [ -f "$DIST_DIR/pc_linux_amd64/pc" ]; then
+                    BINARY_PATH="$DIST_DIR/pc_linux_amd64/pc"
+                elif [ -f "$DIST_DIR/pc_linux_x86_64/pc" ]; then
+                    BINARY_PATH="$DIST_DIR/pc_linux_x86_64/pc"
+                fi
+                ;;
+            "aarch64"|"arm64")
+                if [ -f "$DIST_DIR/pc_linux_arm64/pc" ]; then
+                    BINARY_PATH="$DIST_DIR/pc_linux_arm64/pc"
+                fi
+                ;;
+            "armv7l"|"arm")
+                if [ -f "$DIST_DIR/pc_linux_arm/pc" ]; then
+                    BINARY_PATH="$DIST_DIR/pc_linux_arm/pc"
+                fi
+                ;;
+        esac
+        
+        if [ -z "$BINARY_PATH" ]; then
+            print_error "No suitable Linux binary found for architecture $ARCH"
+            print_status "Available binaries:"
+            ls -la "$DIST_DIR"/*/pc 2>/dev/null || echo "No binaries found"
+            exit 1
+        fi
+        ;;
+    "mingw64_nt"*|"msys_nt"*|"cygwin"*)
+        # Windows (Git Bash, MSYS2, Cygwin)
+        if [ -f "$DIST_DIR/pc_windows_amd64/pc.exe" ]; then
+            BINARY_PATH="$DIST_DIR/pc_windows_amd64/pc.exe"
+        elif [ -f "$DIST_DIR/pc_windows_x86_64/pc.exe" ]; then
+            BINARY_PATH="$DIST_DIR/pc_windows_x86_64/pc.exe"
+        else
+            print_error "No suitable Windows binary found"
+            print_status "Available binaries:"
+            ls -la "$DIST_DIR"/*/pc.exe 2>/dev/null || echo "No binaries found"
+            exit 1
+        fi
+        ;;
+    *)
+        print_error "Unsupported operating system: $OS"
+        exit 1
+        ;;
+esac
+
+# Check if binary exists and is executable
+if [ ! -f "$BINARY_PATH" ]; then
+    print_error "Binary not found: $BINARY_PATH"
+    exit 1
+fi
+
+if [ ! -x "$BINARY_PATH" ]; then
+    print_warning "Binary is not executable, making it executable..."
+    chmod +x "$BINARY_PATH"
+fi
+
+print_status "Running: $BINARY_PATH $*"
+
+# Execute the binary with all passed arguments
+exec "$BINARY_PATH" "$@" 

--- a/pcdev.ps1
+++ b/pcdev.ps1
@@ -1,0 +1,80 @@
+# pcdev.ps1 - PowerShell version for Windows compatibility
+# Development script to run the Pinecone CLI from dist folder
+
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$Arguments
+)
+
+# Colors for output
+$Red = "Red"
+$Green = "Green"
+$Yellow = "Yellow"
+
+# Function to print colored output
+function Write-Status {
+    param([string]$Message)
+    Write-Host "[pcdev] $Message" -ForegroundColor $Green
+}
+
+function Write-Warning {
+    param([string]$Message)
+    Write-Host "[pcdev] $Message" -ForegroundColor $Yellow
+}
+
+function Write-Error {
+    param([string]$Message)
+    Write-Host "[pcdev] $Message" -ForegroundColor $Red
+}
+
+# Get script directory
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DistDir = Join-Path $ScriptDir "dist"
+
+# Check if dist directory exists
+if (-not (Test-Path $DistDir)) {
+    Write-Error "dist directory not found. Please run 'goreleaser build --single-target --snapshot --clean' first."
+    exit 1
+}
+
+# Detect OS and architecture
+$OS = "windows"
+$Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+
+Write-Status "Detected OS: $OS, Architecture: $Arch"
+
+# Determine the correct binary path
+$BinaryPath = ""
+
+# On Windows, look for .exe files
+$PossiblePaths = @(
+    (Join-Path $DistDir "pc_windows_amd64\pc.exe"),
+    (Join-Path $DistDir "pc_windows_x86_64\pc.exe"),
+    (Join-Path $DistDir "pc_windows_386\pc.exe")
+)
+
+foreach ($path in $PossiblePaths) {
+    if (Test-Path $path) {
+        $BinaryPath = $path
+        Write-Status "Using binary: $path"
+        break
+    }
+}
+
+if (-not $BinaryPath) {
+    Write-Error "No suitable Windows binary found"
+    Write-Status "Available binaries:"
+    Get-ChildItem -Path $DistDir -Recurse -Name "*.exe" | ForEach-Object { Write-Host "  $_" }
+    exit 1
+}
+
+# Check if binary exists
+if (-not (Test-Path $BinaryPath)) {
+    Write-Error "Binary not found: $BinaryPath"
+    exit 1
+}
+
+Write-Status "Running: $BinaryPath $($Arguments -join ' ')"
+
+# Execute the binary with all passed arguments
+& $BinaryPath @Arguments 


### PR DESCRIPTION
## Problem

Contributing docs contain outdated information. Instructions to run locally only address a single OS. There are some warnings about deprecated features while running `goreleaser`

## Solution

The PR updates the docs and introduces a shell script to run the CLI locally in a consistent way regardless of the developer's OS. It also updates the `goreleaser` config to the newer format

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Not sure if this needs special testing
