### PR TITLE
Add new `index create` command

### DIFF
--- a/cmd/pc/main.go
+++ b/cmd/pc/main.go
@@ -4,17 +4,18 @@ Copyright © 2025 Pinecone Systems, Inc.
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	cliRootCmd "github.com/pinecone-io/cli/internal/pkg/cli/command/root"
+	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
+	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
 func main() {
 	executableName := filepath.Base(os.Args[0])
 	if executableName == "pinecone" {
-		fmt.Fprintln(os.Stderr, "⚠️  Warning: The 'pinecone' command is deprecated. Please use 'pc' instead.")
+		pcio.Fprintf(os.Stderr, "⚠️  Warning: The '%s' command is deprecated. Please use '%s' instead.", style.Code("pinecone"), style.Code("pc"))
 	}
 
 	cliRootCmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/fatih/color v1.16.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/pinecone-io/go-pinecone/v4 v4.1.1
+	github.com/pinecone-io/go-pinecone/v4 v4.1.2
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pinecone-io/cli
 go 1.23.0
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/briandowns/spinner v1.23.0
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQ
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/pinecone-io/go-pinecone/v4 v4.1.1 h1:htSmGPf+rKeMtaYNaaC7zLps2jjMOvBz+S/Mq9yQ01g=
-github.com/pinecone-io/go-pinecone/v4 v4.1.1/go.mod h1:bLU4DLM79YPfaVLOj23yBPsIohnZDIuUmnTsQXWHzSg=
+github.com/pinecone-io/go-pinecone/v4 v4.1.2 h1:bxfPX6sKhCiUVkrRShNBrSJHiT66p7fuS/IgAYDDmLU=
+github.com/pinecone-io/go-pinecone/v4 v4.1.2/go.mod h1:bLU4DLM79YPfaVLOj23yBPsIohnZDIuUmnTsQXWHzSg=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/text"
 	"github.com/spf13/cobra"
@@ -13,9 +14,15 @@ its contents.`, 80)
 
 func NewIndexCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "index <command>",
-		Short:   "Work with indexes",
-		Long:    helpText,
+		Use:   "index",
+		Short: "Work with indexes",
+		Long:  helpText,
+		Example: heredoc.Doc(`
+			$ pc index list
+			$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
+			$ pc index describe --name my-index
+			$ pc index delete --name my-index
+		`),
 		GroupID: help.GROUP_VECTORDB.ID,
 	}
 

--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -21,6 +21,7 @@ func NewIndexCmd() *cobra.Command {
 
 	cmd.AddCommand(NewDescribeCmd())
 	cmd.AddCommand(NewListCmd())
+	cmd.AddCommand(NewCreateIndexCmd())
 	cmd.AddCommand(NewCreateServerlessCmd())
 	cmd.AddCommand(NewCreatePodCmd())
 	cmd.AddCommand(NewConfigureIndexCmd())

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/pinecone-io/cli/internal/pkg/utils/docslinks"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -75,8 +76,8 @@ func NewCreateIndexCmd() *cobra.Command {
 			- Pod
 
 		For detailed documentation, see:
-			https://docs.pinecone.io/guides/index-data/create-an-index
-		`, style.Code("pc index create")),
+		%s
+		`, style.Code("pc index create"), style.URL(docslinks.DocsIndexCreate)),
 		Example: heredoc.Doc(`
 		# create a serverless index
 		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -63,48 +64,68 @@ func NewCreateIndexCmd() *cobra.Command {
 	options := createIndexOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "create",
-		Short:   "Create a new index with the specified configuration",
-		Example: "",
+		Use:   "create",
+		Short: "Create a new index with the specified configuration",
+		Long: heredoc.Docf(`
+		The %s command creates a new index with the specified configuration. There are several different types of indexes
+		you can create depending on the configuration provided:
+
+			- Serverless (dense or sparse)
+			- Integrated 
+			- Pod
+
+		For detailed documentation, see:
+			https://docs.pinecone.io/guides/index-data/create-an-index
+		`, style.Code("pc index create")),
+		Example: heredoc.Doc(`
+		# create a serverless index
+		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
+
+		# create a pod index
+		$ pc index create --name my-index --dimension 1536 --metric cosine --environment prod --pod-type s1 --shards 2 --replicas 2
+
+		# create an integrated index
+		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreateIndexCmd(options)
 		},
 	}
 
 	// Required flags
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to create")
-	cmd.MarkFlagRequired("name")
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "Name of index to create")
+	_ = cmd.MarkFlagRequired("name")
 
 	// Serverless & Pods
-	cmd.Flags().StringVar(&options.sourceCollection, "source_collection", "", "when creating an index from a collection")
+	cmd.Flags().StringVar(&options.sourceCollection, "source_collection", "", "When creating an index from a collection")
 
 	// Serverless & Integrated
-	cmd.Flags().StringVarP(&options.cloud, "cloud", "c", "", "cloud provider where you would like to deploy your index")
-	cmd.Flags().StringVarP(&options.region, "region", "r", "", "cloud region where you would like to deploy your index")
+	cmd.Flags().StringVarP(&options.cloud, "cloud", "c", "", "Cloud provider where you would like to deploy your index")
+	cmd.Flags().StringVarP(&options.region, "region", "r", "", "Cloud region where you would like to deploy your index")
 
 	// Serverless flags
-	cmd.Flags().StringVarP(&options.vectorType, "vector_type", "v", "", "vector type to use. One of: dense, sparse")
+	cmd.Flags().StringVarP(&options.vectorType, "vector_type", "v", "", "Vector type to use. One of: dense, sparse")
 
 	// Pod flags
-	cmd.Flags().StringVar(&options.environment, "environment", "", "environment of the index to create")
-	cmd.Flags().StringVar(&options.podType, "pod_type", "", "type of pod to use")
-	cmd.Flags().Int32Var(&options.shards, "shards", 1, "shards of the index to create")
-	cmd.Flags().Int32Var(&options.replicas, "replicas", 1, "replicas of the index to create")
-	cmd.Flags().StringSliceVar(&options.metadataConfig, "metadata_config", []string{}, "metadata configuration to limit the fields that are indexed for search")
+	cmd.Flags().StringVar(&options.environment, "environment", "", "Environment of the index to create")
+	cmd.Flags().StringVar(&options.podType, "pod_type", "", "Type of pod to use")
+	cmd.Flags().Int32Var(&options.shards, "shards", 1, "Shards of the index to create")
+	cmd.Flags().Int32Var(&options.replicas, "replicas", 1, "Replicas of the index to create")
+	cmd.Flags().StringSliceVar(&options.metadataConfig, "metadata_config", []string{}, "Metadata configuration to limit the fields that are indexed for search")
 
 	// Integrated flags
-	cmd.Flags().StringVar(&options.model, "model", "", "the name of the embedding model to use for the index")
-	cmd.Flags().StringToStringVar(&options.fieldMap, "field_map", map[string]string{}, "identifies the name of the text field from your document model that will be embedded")
-	cmd.Flags().StringToStringVar(&options.readParameters, "read_parameters", map[string]string{}, "the read parameters for the embedding model")
-	cmd.Flags().StringToStringVar(&options.writeParameters, "write_parameters", map[string]string{}, "the write parameters for the embedding model")
+	cmd.Flags().StringVar(&options.model, "model", "", "The name of the embedding model to use for the index")
+	cmd.Flags().StringToStringVar(&options.fieldMap, "field_map", map[string]string{}, "Identifies the name of the text field from your document model that will be embedded")
+	cmd.Flags().StringToStringVar(&options.readParameters, "read_parameters", map[string]string{}, "The read parameters for the embedding model")
+	cmd.Flags().StringToStringVar(&options.writeParameters, "write_parameters", map[string]string{}, "The write parameters for the embedding model")
 
 	// Optional flags
-	cmd.Flags().Int32VarP(&options.dimension, "dimension", "d", 0, "dimension of the index to create")
-	cmd.Flags().StringVarP(&options.metric, "metric", "m", "cosine", "metric to use. One of: cosine, euclidean, dotproduct")
-	cmd.Flags().StringVar(&options.deletionProtection, "deletion_protection", "", "whether to enable deletion protection for the index. One of: enabled, disabled")
-	cmd.Flags().StringToStringVar(&options.tags, "tags", map[string]string{}, "custom user tags to add to an index")
+	cmd.Flags().Int32VarP(&options.dimension, "dimension", "d", 0, "Dimension of the index to create")
+	cmd.Flags().StringVarP(&options.metric, "metric", "m", "cosine", "Metric to use. One of: cosine, euclidean, dotproduct")
+	cmd.Flags().StringVar(&options.deletionProtection, "deletion_protection", "", "Whether to enable deletion protection for the index. One of: enabled, disabled")
+	cmd.Flags().StringToStringVar(&options.tags, "tags", map[string]string{}, "Custom user tags to add to an index")
 
-	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
+	cmd.Flags().BoolVar(&options.json, "json", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -82,10 +82,10 @@ func NewCreateIndexCmd() *cobra.Command {
 		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
 
 		# create a pod index
-		$ pc index create --name my-index --dimension 1536 --metric cosine --environment prod --pod-type s1 --shards 2 --replicas 2
+		$ pc index create --name my-index --dimension 1536 --metric cosine --environment us-east-1-aws --pod-type p1.x1 --shards 2 --replicas 2
 
 		# create an integrated index
-		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large
+		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large --field_map text=chunk_text
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreateIndexCmd(options)

--- a/internal/pkg/cli/command/index/create_index.go
+++ b/internal/pkg/cli/command/index/create_index.go
@@ -1,0 +1,309 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/log"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
+	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
+	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
+	"github.com/pinecone-io/cli/internal/pkg/utils/style"
+	"github.com/pinecone-io/cli/internal/pkg/utils/text"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
+	"github.com/spf13/cobra"
+)
+
+type indexType string
+
+const (
+	indexTypeServerless indexType = "serverless"
+	indexTypeIntegrated indexType = "integrated"
+	indexTypePod        indexType = "pod"
+)
+
+type createIndexOptions struct {
+	// required for all index types
+	name string
+
+	// serverless only
+	vectorType string
+
+	// serverless & integrated
+	cloud  string
+	region string
+
+	// serverless & pods
+	sourceCollection string
+
+	// pods only
+	environment    string
+	podType        string
+	shards         int32
+	replicas       int32
+	metadataConfig []string
+
+	// integrated only
+	model           string
+	fieldMap        map[string]string
+	readParameters  map[string]string
+	writeParameters map[string]string
+
+	// optional for all index types
+	dimension          int32
+	metric             string
+	deletionProtection string
+	tags               map[string]string
+
+	json bool
+}
+
+func NewCreateIndexCmd() *cobra.Command {
+	options := createIndexOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a new index with the specified configuration",
+		Example: "",
+		Run: func(cmd *cobra.Command, args []string) {
+			runCreateIndexCmd(options)
+		},
+	}
+
+	// Required flags
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to create")
+	cmd.MarkFlagRequired("name")
+
+	// Serverless & Pods
+	cmd.Flags().StringVar(&options.sourceCollection, "source_collection", "", "when creating an index from a collection")
+
+	// Serverless & Integrated
+	cmd.Flags().StringVarP(&options.cloud, "cloud", "c", "", "cloud provider where you would like to deploy your index")
+	cmd.Flags().StringVarP(&options.region, "region", "r", "", "cloud region where you would like to deploy your index")
+
+	// Serverless flags
+	cmd.Flags().StringVarP(&options.vectorType, "vector_type", "v", "", "vector type to use. One of: dense, sparse")
+
+	// Pod flags
+	cmd.Flags().StringVar(&options.environment, "environment", "", "environment of the index to create")
+	cmd.Flags().StringVar(&options.podType, "pod_type", "", "type of pod to use")
+	cmd.Flags().Int32Var(&options.shards, "shards", 1, "shards of the index to create")
+	cmd.Flags().Int32Var(&options.replicas, "replicas", 1, "replicas of the index to create")
+	cmd.Flags().StringSliceVar(&options.metadataConfig, "metadata_config", []string{}, "metadata configuration to limit the fields that are indexed for search")
+
+	// Integrated flags
+	cmd.Flags().StringVar(&options.model, "model", "", "the name of the embedding model to use for the index")
+	cmd.Flags().StringToStringVar(&options.fieldMap, "field_map", map[string]string{}, "identifies the name of the text field from your document model that will be embedded")
+	cmd.Flags().StringToStringVar(&options.readParameters, "read_parameters", map[string]string{}, "the read parameters for the embedding model")
+	cmd.Flags().StringToStringVar(&options.writeParameters, "write_parameters", map[string]string{}, "the write parameters for the embedding model")
+
+	// Optional flags
+	cmd.Flags().Int32VarP(&options.dimension, "dimension", "d", 0, "dimension of the index to create")
+	cmd.Flags().StringVarP(&options.metric, "metric", "m", "cosine", "metric to use. One of: cosine, euclidean, dotproduct")
+	cmd.Flags().StringVar(&options.deletionProtection, "deletion_protection", "", "whether to enable deletion protection for the index. One of: enabled, disabled")
+	cmd.Flags().StringToStringVar(&options.tags, "tags", map[string]string{}, "custom user tags to add to an index")
+
+	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
+
+	return cmd
+}
+
+func runCreateIndexCmd(options createIndexOptions) {
+	ctx := context.Background()
+	pc := sdk.NewPineconeClient()
+
+	// validate and derive index type from arguments
+	err := options.validate()
+	if err != nil {
+		exit.Error(err)
+		return
+	}
+	idxType, err := options.deriveIndexType()
+	if err != nil {
+		exit.Error(err)
+		return
+	}
+
+	// index tags
+	var indexTags *pinecone.IndexTags
+	if len(options.tags) > 0 {
+		tags := pinecone.IndexTags(options.tags)
+		indexTags = &tags
+	}
+
+	// created index
+	var idx *pinecone.Index
+
+	switch idxType {
+	case indexTypeServerless:
+		// create serverless index
+		fmt.Printf("dimension %d\n", options.dimension)
+		args := pinecone.CreateServerlessIndexRequest{
+			Name:               options.name,
+			Cloud:              pinecone.Cloud(options.cloud),
+			Region:             options.region,
+			Metric:             pointerOrNil(pinecone.IndexMetric(options.metric)),
+			DeletionProtection: pointerOrNil(pinecone.DeletionProtection(options.deletionProtection)),
+			Dimension:          pointerOrNil(options.dimension),
+			VectorType:         pointerOrNil(options.vectorType),
+			Tags:               indexTags,
+			SourceCollection:   pointerOrNil(options.sourceCollection),
+		}
+
+		idx, err = pc.CreateServerlessIndex(ctx, &args)
+		if err != nil {
+			msg.FailMsg("Failed to create serverless index %s: %s\n", style.Emphasis(options.name), err)
+			exit.Error(err)
+		}
+	case indexTypePod:
+		// create pod index
+		var metadataConfig *pinecone.PodSpecMetadataConfig
+		if len(options.metadataConfig) > 0 {
+			metadataConfig = &pinecone.PodSpecMetadataConfig{
+				Indexed: &options.metadataConfig,
+			}
+		}
+		args := pinecone.CreatePodIndexRequest{
+			Name:               options.name,
+			Dimension:          options.dimension,
+			Environment:        options.environment,
+			PodType:            options.podType,
+			Shards:             options.shards,
+			Replicas:           options.replicas,
+			Metric:             pointerOrNil(pinecone.IndexMetric(options.metric)),
+			DeletionProtection: pointerOrNil(pinecone.DeletionProtection(options.deletionProtection)),
+			SourceCollection:   pointerOrNil(options.sourceCollection),
+			Tags:               indexTags,
+			MetadataConfig:     metadataConfig,
+		}
+
+		idx, err = pc.CreatePodIndex(ctx, &args)
+		if err != nil {
+			msg.FailMsg("Failed to create pod index %s: %s\n", style.Emphasis(options.name), err)
+			exit.Error(err)
+		}
+	case indexTypeIntegrated:
+		// create integrated index
+		readParams := toInterfaceMap(options.readParameters)
+		writeParams := toInterfaceMap(options.writeParameters)
+
+		args := pinecone.CreateIndexForModelRequest{
+			Name:               options.name,
+			Cloud:              pinecone.Cloud(options.cloud),
+			Region:             options.region,
+			DeletionProtection: pointerOrNil(pinecone.DeletionProtection(options.deletionProtection)),
+			Embed: pinecone.CreateIndexForModelEmbed{
+				Model:           options.model,
+				FieldMap:        toInterfaceMap(options.fieldMap),
+				ReadParameters:  &readParams,
+				WriteParameters: &writeParams,
+			},
+		}
+
+		idx, err = pc.CreateIndexForModel(ctx, &args)
+		if err != nil {
+			msg.FailMsg("Failed to create integrated index %s: %s\n", style.Emphasis(options.name), err)
+			exit.Error(err)
+		}
+	default:
+		err := pcio.Errorf("invalid index type")
+		log.Error().Err(err).Msg("Error creating index")
+		exit.Error(err)
+	}
+
+	renderSuccessOutput(idx, options)
+}
+
+func renderSuccessOutput(idx *pinecone.Index, options createIndexOptions) {
+	if options.json {
+		json := text.IndentJSON(idx)
+		pcio.Println(json)
+		return
+	}
+
+	describeCommand := pcio.Sprintf("pc index describe --name %s", idx.Name)
+	msg.SuccessMsg("Index %s created successfully. Run %s to check status. \n\n", style.Emphasis(idx.Name), style.Code(describeCommand))
+	presenters.PrintDescribeIndexTable(idx)
+}
+
+// use the derived index type to validate specific input params by index type
+func (c *createIndexOptions) validate() error {
+	// name required for all index types
+	if c.name == "" {
+		err := pcio.Errorf("name is required")
+		log.Error().Err(err).Msg("Error creating index")
+		return err
+	}
+
+	// environment and cloud/region cannot be provided together
+	if c.cloud != "" && c.region != "" && c.environment != "" {
+		err := pcio.Errorf("cloud, region, and environment cannot be provided together")
+		log.Error().Err(err).Msg("Error creating index")
+		return err
+	}
+
+	idxType, err := c.deriveIndexType()
+	if err != nil {
+		return err
+	}
+
+	switch idxType {
+	case indexTypeServerless:
+		// validate serverless
+
+		return nil
+	case indexTypePod:
+		// validate pod
+
+		// if user passed environment, and embed - ERROR
+		// if vectorType is "sparse" for pods - ERROR
+
+		return nil
+	case indexTypeIntegrated:
+		// validate integrated
+
+		return nil
+	default:
+		err := pcio.Errorf("invalid index type")
+		log.Error().Err(err).Msg("Error validating index configuration")
+		return err
+	}
+}
+
+// determine the type of index being created based on high level input params
+func (c *createIndexOptions) deriveIndexType() (indexType, error) {
+	if c.cloud != "" && c.region != "" {
+		if c.model != "" {
+			return indexTypeIntegrated, nil
+		} else {
+			return indexTypeServerless, nil
+		}
+	}
+	if c.environment != "" {
+		return indexTypePod, nil
+	}
+	return "", errors.New("invalid index. Please provide either environment, or cloud and region")
+}
+
+func pointerOrNil[T comparable](value T) *T {
+	var zero T // set to zero-value of generic type T
+	if value == zero {
+		return nil
+	}
+	return &value
+}
+
+func toInterfaceMap(in map[string]string) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+
+	interfaceMap := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		interfaceMap[k] = v
+	}
+	return interfaceMap
+}

--- a/internal/pkg/cli/command/index/create_index.go
+++ b/internal/pkg/cli/command/index/create_index.go
@@ -2,8 +2,6 @@ package index
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
@@ -140,7 +138,6 @@ func runCreateIndexCmd(options createIndexOptions) {
 	switch idxType {
 	case indexTypeServerless:
 		// create serverless index
-		fmt.Printf("dimension %d\n", options.dimension)
 		args := pinecone.CreateServerlessIndexRequest{
 			Name:               options.name,
 			Cloud:              pinecone.Cloud(options.cloud),
@@ -260,7 +257,7 @@ func (c *createIndexOptions) deriveIndexType() (indexType, error) {
 	if c.environment != "" {
 		return indexTypePod, nil
 	}
-	return "", errors.New("invalid index type. Please provide either environment, or cloud and region")
+	return "", pcio.Error("invalid index type. Please provide either environment, or cloud and region")
 }
 
 func pointerOrNil[T comparable](value T) *T {

--- a/internal/pkg/cli/command/index/create_index.go
+++ b/internal/pkg/cli/command/index/create_index.go
@@ -229,7 +229,7 @@ func renderSuccessOutput(idx *pinecone.Index, options createIndexOptions) {
 	presenters.PrintDescribeIndexTable(idx)
 }
 
-// use the derived index type to validate specific input params by index type
+// validate specific input params
 func (c *createIndexOptions) validate() error {
 	// name required for all index types
 	if c.name == "" {
@@ -245,32 +245,7 @@ func (c *createIndexOptions) validate() error {
 		return err
 	}
 
-	idxType, err := c.deriveIndexType()
-	if err != nil {
-		return err
-	}
-
-	switch idxType {
-	case indexTypeServerless:
-		// validate serverless
-
-		return nil
-	case indexTypePod:
-		// validate pod
-
-		// if user passed environment, and embed - ERROR
-		// if vectorType is "sparse" for pods - ERROR
-
-		return nil
-	case indexTypeIntegrated:
-		// validate integrated
-
-		return nil
-	default:
-		err := pcio.Errorf("invalid index type")
-		log.Error().Err(err).Msg("Error validating index configuration")
-		return err
-	}
+	return nil
 }
 
 // determine the type of index being created based on high level input params
@@ -285,7 +260,7 @@ func (c *createIndexOptions) deriveIndexType() (indexType, error) {
 	if c.environment != "" {
 		return indexTypePod, nil
 	}
-	return "", errors.New("invalid index. Please provide either environment, or cloud and region")
+	return "", errors.New("invalid index type. Please provide either environment, or cloud and region")
 }
 
 func pointerOrNil[T comparable](value T) *T {

--- a/internal/pkg/cli/command/index/create_index.go
+++ b/internal/pkg/cli/command/index/create_index.go
@@ -268,12 +268,12 @@ func pointerOrNil[T comparable](value T) *T {
 	return &value
 }
 
-func toInterfaceMap(in map[string]string) map[string]interface{} {
+func toInterfaceMap(in map[string]string) map[string]any {
 	if in == nil {
 		return nil
 	}
 
-	interfaceMap := make(map[string]interface{}, len(in))
+	interfaceMap := make(map[string]any, len(in))
 	for k, v := range in {
 		interfaceMap[k] = v
 	}

--- a/internal/pkg/cli/command/index/create_pod.go
+++ b/internal/pkg/cli/command/index/create_pod.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"os"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -43,13 +44,13 @@ func NewCreatePodCmd() *cobra.Command {
 
 	// Required flags
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to create")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().Int32VarP(&options.dimension, "dimension", "d", 0, "dimension of the index to create")
-	cmd.MarkFlagRequired("dimension")
+	_ = cmd.MarkFlagRequired("dimension")
 	cmd.Flags().StringVarP(&options.environment, "environment", "e", "", "environment of the index to create")
-	cmd.MarkFlagRequired("environment")
+	_ = cmd.MarkFlagRequired("environment")
 	cmd.Flags().StringVarP(&options.podType, "pod_type", "t", "", "type of pod to use")
-	cmd.MarkFlagRequired("pod_type")
+	_ = cmd.MarkFlagRequired("pod_type")
 
 	// Optional flags
 	cmd.Flags().StringVarP(&options.metric, "metric", "m", "cosine", "metric to use. One of: cosine, euclidean, dotproduct")
@@ -58,7 +59,7 @@ func NewCreatePodCmd() *cobra.Command {
 	cmd.Flags().Int32VarP(&options.replicas, "replicas", "r", 1, "replicas of the index to create")
 	cmd.Flags().StringVarP(&options.sourceCollection, "source_collection", "c", "", "When creating a pod index using data from a collection, the name of the source collection")
 	cmd.Flags().StringVarP(&options.deletionProtection, "deletion_protection", "p", "", "Whether to enable deletion protection for the index")
-	cmd.MarkFlagRequired("sourceCollection")
+	_ = cmd.MarkFlagRequired("sourceCollection")
 
 	return cmd
 }
@@ -66,6 +67,9 @@ func NewCreatePodCmd() *cobra.Command {
 func runCreatePodCmd(options createPodOptions) {
 	ctx := context.Background()
 	pc := sdk.NewPineconeClient()
+
+	// Deprecation warning
+	pcio.Fprintf(os.Stderr, "⚠️  Warning: The '%s' command is deprecated. Please use '%s' instead.", style.Code("index create-pod"), style.Code("index create"))
 
 	metric := pinecone.IndexMetric(options.metric)
 	deletionProtection := pinecone.DeletionProtection(options.deletionProtection)

--- a/internal/pkg/cli/command/index/create_serverless.go
+++ b/internal/pkg/cli/command/index/create_serverless.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"os"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -38,13 +39,13 @@ func NewCreateServerlessCmd() *cobra.Command {
 
 	// Required flags
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the index")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVarP(&options.cloud, "cloud", "c", "", "cloud provider where you would like to deploy")
-	cmd.MarkFlagRequired("cloud")
+	_ = cmd.MarkFlagRequired("cloud")
 	cmd.Flags().StringVarP(&options.region, "region", "r", "", "cloud region where you would like to deploy")
-	cmd.MarkFlagRequired("region")
+	_ = cmd.MarkFlagRequired("region")
 	cmd.Flags().Int32VarP(&options.dimension, "dimension", "d", 0, "dimension of the index to create")
-	cmd.MarkFlagRequired("dimension")
+	_ = cmd.MarkFlagRequired("dimension")
 
 	// Optional flags
 	cmd.Flags().StringVarP(&options.metric, "metric", "m", "cosine", "metric to use. One of: cosine, euclidean, dotproduct")
@@ -57,6 +58,9 @@ func NewCreateServerlessCmd() *cobra.Command {
 func runCreateServerlessCmd(options createServerlessOptions) {
 	ctx := context.Background()
 	pc := sdk.NewPineconeClient()
+
+	// Deprecation warning
+	pcio.Fprintf(os.Stderr, "⚠️  Warning: The '%s' command is deprecated. Please use '%s' instead.", style.Code("index create-serverless"), style.Code("index create"))
 
 	// Create variables for optional fields that need pointers
 	var indexMetric *pinecone.IndexMetric

--- a/internal/pkg/cli/command/index/delete.go
+++ b/internal/pkg/cli/command/index/delete.go
@@ -40,7 +40,7 @@ func NewDeleteCmd() *cobra.Command {
 	}
 
 	// required flags
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to describe")
+	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to delete")
 	cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/pkg/cli/command/index/delete.go
+++ b/internal/pkg/cli/command/index/delete.go
@@ -41,7 +41,7 @@ func NewDeleteCmd() *cobra.Command {
 
 	// required flags
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to delete")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/index/describe.go
+++ b/internal/pkg/cli/command/index/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCmd() *cobra.Command {
 
 	// required flags
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to describe")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 
 	// optional flags
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")

--- a/internal/pkg/cli/command/index/index_test.go
+++ b/internal/pkg/cli/command/index/index_test.go
@@ -1,0 +1,98 @@
+package index
+
+import "testing"
+
+func TestDeriveIndexType(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     createIndexOptions
+		expected    indexType
+		expectError bool
+	}{
+		{
+			name: "serverless - cloud, region",
+			options: createIndexOptions{
+				cloud:  "aws",
+				region: "us-east-1",
+			},
+			expected: indexTypeServerless,
+		},
+		{
+			name: "integrated - cloud, region, model",
+			options: createIndexOptions{
+				cloud:  "aws",
+				region: "us-east-1",
+				model:  "multilingual-e5-large",
+			},
+			expected: indexTypeIntegrated,
+		},
+		{
+			name: "pods - environment",
+			options: createIndexOptions{
+				environment: "us-east-1-gcp",
+			},
+			expected: indexTypePod,
+		},
+		{
+			name: "serverless - prioritized with environment",
+			options: createIndexOptions{
+				cloud:       "aws",
+				region:      "us-east-1",
+				environment: "us-east-1-gcp",
+			},
+			expected: indexTypeServerless,
+		},
+		{
+			name:        "error - no input",
+			options:     createIndexOptions{},
+			expectError: true,
+		},
+		{
+			name: "error - cloud and model only",
+			options: createIndexOptions{
+				cloud: "aws",
+				model: "multilingual-e5-large",
+			},
+			expectError: true,
+		},
+		{
+			name: "error - cloud only",
+			options: createIndexOptions{
+				cloud: "aws",
+			},
+			expectError: true,
+		},
+		{
+			name: "error - model only",
+			options: createIndexOptions{
+				model: "multilingual-e5-large",
+			},
+			expectError: true,
+		},
+		{
+			name: "error - region only",
+			options: createIndexOptions{
+				region: "us-east-1",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.options.deriveIndexType()
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if got != tt.expected {
+					t.Errorf("expected %v, got %v", tt.expected, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -42,6 +42,7 @@ func NewLoginCmd() *cobra.Command {
 			err := GetAndSetAccessToken(nil)
 			if err != nil {
 				exit.Error(pcio.Errorf("error acquiring access token while logging in: %w", err))
+				return
 			}
 
 			// Parse token claims to get orgId

--- a/internal/pkg/cli/command/project/create.go
+++ b/internal/pkg/cli/command/project/create.go
@@ -50,7 +50,7 @@ func NewCreateProjectCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the project")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().Int32VarP(&options.pod_quota, "pod_quota", "p", 5, "maximum number of pods allowed in the project across all indexes")
 	return cmd
 }

--- a/internal/pkg/cli/command/project/delete.go
+++ b/internal/pkg/cli/command/project/delete.go
@@ -83,7 +83,7 @@ func NewDeleteProjectCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&options.json, "json", false, "output as JSON")
 	cmd.Flags().BoolVar(&options.yes, "yes", false, "skip confirmation prompt")
 	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of the project")
-	cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
 

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -115,7 +115,6 @@ func NewTargetCmd() *cobra.Command {
 
 				// If the org chosen differs from the current orgId in the token, we need to login again
 				if currentTokenOrgId != targetOrg.Id {
-					pcio.Printf("GETTING AND SETTING NEW ACCESS TOKEN for target org %s\n", targetOrg.Name)
 					err = login.GetAndSetAccessToken(&targetOrg.Id)
 					if err != nil {
 						msg.FailMsg("Failed to get access token: %s", err)

--- a/internal/pkg/utils/docslinks/links.go
+++ b/internal/pkg/utils/docslinks/links.go
@@ -2,5 +2,6 @@ package docslinks
 
 const (
 	DocsHome                      = "https://docs.pinecone.io"
+	DocsIndexCreate               = "https://docs.pinecone.io/guides/index-data/create-an-index"
 	UnderstandingCollectionsGuide = "https://docs.pinecone.io/guides/indexes/understanding-collections"
 )

--- a/internal/pkg/utils/msg/message.go
+++ b/internal/pkg/utils/msg/message.go
@@ -5,27 +5,27 @@ import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
-func FailMsg(format string, a ...interface{}) {
+func FailMsg(format string, a ...any) {
 	formatted := pcio.Sprintf(format, a...)
 	pcio.Println(style.FailMsg(formatted))
 }
 
-func SuccessMsg(format string, a ...interface{}) {
+func SuccessMsg(format string, a ...any) {
 	formatted := pcio.Sprintf(format, a...)
 	pcio.Println(style.SuccessMsg(formatted))
 }
 
-func WarnMsg(format string, a ...interface{}) {
+func WarnMsg(format string, a ...any) {
 	formatted := pcio.Sprintf(format, a...)
 	pcio.Println(style.WarnMsg(formatted))
 }
 
-func InfoMsg(format string, a ...interface{}) {
+func InfoMsg(format string, a ...any) {
 	formatted := pcio.Sprintf(format, a...)
 	pcio.Println(style.InfoMsg(formatted))
 }
 
-func HintMsg(format string, a ...interface{}) {
+func HintMsg(format string, a ...any) {
 	formatted := pcio.Sprintf(format, a...)
 	pcio.Println(style.Hint(formatted))
 }

--- a/internal/pkg/utils/network/request.go
+++ b/internal/pkg/utils/network/request.go
@@ -37,11 +37,11 @@ func buildRequest(verb string, path string, body *bytes.Buffer) (*http.Request, 
 		}
 	}
 
-	applyHeaders(req, path)
+	applyHeaders(req)
 	return req, nil
 }
 
-func applyHeaders(req *http.Request, url string) {
+func applyHeaders(req *http.Request) {
 	// apply to all requests
 	req.Header.Add("User-Agent", "Pinecone CLI")
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/pkg/utils/oauth2/logging.go
+++ b/internal/pkg/utils/oauth2/logging.go
@@ -45,7 +45,6 @@ func LogTokenClaims(token *oauth2.Token, msg string) {
 }
 
 func ParseClaimsUnverified(token *oauth2.Token) (*MyCustomClaims, error) {
-
 	var p = &jwt.Parser{}
 	var claims MyCustomClaims
 	if token.AccessToken == "" {

--- a/internal/pkg/utils/pcio/print.go
+++ b/internal/pkg/utils/pcio/print.go
@@ -29,28 +29,28 @@ func Print(a any) {
 	}
 }
 
-func Printf(format string, a ...interface{}) {
+func Printf(format string, a ...any) {
 	if !quiet {
 		fmt.Printf(format, a...)
 		return
 	}
 }
 
-func Fprintf(w io.Writer, format string, a ...interface{}) {
+func Fprintf(w io.Writer, format string, a ...any) {
 	if !quiet {
 		fmt.Fprintf(w, format, a...)
 		return
 	}
 }
 
-func Fprintln(w io.Writer, a ...interface{}) {
+func Fprintln(w io.Writer, a ...any) {
 	if !quiet {
 		fmt.Fprintln(w, a...)
 		return
 	}
 }
 
-func Fprint(w io.Writer, a ...interface{}) {
+func Fprint(w io.Writer, a ...any) {
 	if !quiet {
 		fmt.Fprint(w, a...)
 		return
@@ -58,16 +58,16 @@ func Fprint(w io.Writer, a ...interface{}) {
 }
 
 // alias Sprintf to fmt.Sprintf
-func Sprintf(format string, a ...interface{}) string {
+func Sprintf(format string, a ...any) string {
 	return fmt.Sprintf(format, a...)
 }
 
 // alias Errorf to fmt.Errorf
-func Errorf(format string, a ...interface{}) error {
+func Errorf(format string, a ...any) error {
 	return fmt.Errorf(format, a...)
 }
 
 // alias Error to fmt.Errorf
-func Error(a ...interface{}) error {
+func Error(a ...any) error {
 	return fmt.Errorf(fmt.Sprint(a...))
 }

--- a/internal/pkg/utils/presenters/index_description.go
+++ b/internal/pkg/utils/presenters/index_description.go
@@ -39,17 +39,15 @@ func PrintDescribeIndexTable(idx *pinecone.Index) {
 	pcio.Fprint(writer, header)
 
 	pcio.Fprintf(writer, "Name\t%s\n", idx.Name)
-	if idx.Dimension != nil {
-		pcio.Fprintf(writer, "Dimension\t%d\n", *idx.Dimension)
-	} else {
-		pcio.Fprintf(writer, "Dimension\tnil\n")
-	}
+	pcio.Fprintf(writer, "Dimension\t%v\n", DisplayOrNone(idx.Dimension))
 	pcio.Fprintf(writer, "Metric\t%s\n", string(idx.Metric))
 	pcio.Fprintf(writer, "Deletion Protection\t%s\n", ColorizeDeletionProtection(idx.DeletionProtection))
+	pcio.Fprintf(writer, "Vector Type\t%s\n", DisplayOrNone(idx.VectorType))
 	pcio.Fprintf(writer, "\t\n")
 	pcio.Fprintf(writer, "State\t%s\n", ColorizeState(idx.Status.State))
 	pcio.Fprintf(writer, "Ready\t%s\n", ColorizeBool(idx.Status.Ready))
 	pcio.Fprintf(writer, "Host\t%s\n", style.Emphasis(idx.Host))
+	pcio.Fprintf(writer, "Private Host\t%s\n", DisplayOrNone(idx.PrivateHost))
 	pcio.Fprintf(writer, "\t\n")
 
 	var specType string
@@ -62,11 +60,25 @@ func PrintDescribeIndexTable(idx *pinecone.Index) {
 		pcio.Fprintf(writer, "ShardCount\t%d\n", idx.Spec.Pod.ShardCount)
 		pcio.Fprintf(writer, "PodCount\t%d\n", idx.Spec.Pod.PodCount)
 		pcio.Fprintf(writer, "MetadataConfig\t%s\n", text.InlineJSON(idx.Spec.Pod.MetadataConfig))
+		pcio.Fprintf(writer, "Source Collection\t%s\n", DisplayOrNone(idx.Spec.Pod.SourceCollection))
 	} else {
 		specType = "serverless"
 		pcio.Fprintf(writer, "Spec\t%s\n", specType)
 		pcio.Fprintf(writer, "Cloud\t%s\n", idx.Spec.Serverless.Cloud)
 		pcio.Fprintf(writer, "Region\t%s\n", idx.Spec.Serverless.Region)
+		pcio.Fprintf(writer, "Source Collection\t%s\n", DisplayOrNone(idx.Spec.Serverless.SourceCollection))
+	}
+	pcio.Fprintf(writer, "\t\n")
+
+	if idx.Embed != nil {
+		pcio.Fprintf(writer, "Model\t%s\n", idx.Embed.Model)
+		pcio.Fprintf(writer, "Field Map\t%s\n", text.InlineJSON(idx.Embed.FieldMap))
+		pcio.Fprintf(writer, "Read Parameters\t%s\n", text.InlineJSON(idx.Embed.ReadParameters))
+		pcio.Fprintf(writer, "Write Parameters\t%s\n", text.InlineJSON(idx.Embed.WriteParameters))
+	}
+
+	if idx.Tags != nil {
+		pcio.Fprintf(writer, "Tags\t%s\n", text.InlineJSON(idx.Tags))
 	}
 
 	writer.Flush()

--- a/internal/pkg/utils/presenters/text.go
+++ b/internal/pkg/utils/presenters/text.go
@@ -1,6 +1,9 @@
 package presenters
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
@@ -9,4 +12,18 @@ func ColorizeBool(b bool) string {
 		return style.StatusGreen("true")
 	}
 	return style.StatusRed("false")
+}
+
+func DisplayOrNone(val interface{}) string {
+	v := reflect.ValueOf(val)
+
+	if !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) {
+		return "<none>"
+	}
+
+	if v.Kind() == reflect.Ptr {
+		return fmt.Sprintf("%v", v.Elem().Interface())
+	}
+
+	return fmt.Sprintf("%v", val)
 }

--- a/internal/pkg/utils/presenters/text.go
+++ b/internal/pkg/utils/presenters/text.go
@@ -13,7 +13,7 @@ func ColorizeBool(b bool) string {
 	return style.StatusRed("false")
 }
 
-func DisplayOrNone(val interface{}) interface{} {
+func DisplayOrNone(val any) any {
 	if val == nil {
 		return "<none>"
 	}

--- a/internal/pkg/utils/presenters/text.go
+++ b/internal/pkg/utils/presenters/text.go
@@ -1,7 +1,6 @@
 package presenters
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
@@ -14,16 +13,23 @@ func ColorizeBool(b bool) string {
 	return style.StatusRed("false")
 }
 
-func DisplayOrNone(val interface{}) string {
-	v := reflect.ValueOf(val)
-
-	if !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) {
+func DisplayOrNone(val interface{}) interface{} {
+	if val == nil {
 		return "<none>"
 	}
 
-	if v.Kind() == reflect.Ptr {
-		return fmt.Sprintf("%v", v.Elem().Interface())
+	v := reflect.ValueOf(val)
+	for v.IsValid() {
+		switch v.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			if v.IsNil() {
+				return "<none>"
+			}
+			v = v.Elem()
+		default:
+			return v.Interface()
+		}
 	}
 
-	return fmt.Sprintf("%v", val)
+	return "<none>"
 }

--- a/internal/pkg/utils/presenters/text_test.go
+++ b/internal/pkg/utils/presenters/text_test.go
@@ -1,0 +1,95 @@
+package presenters
+
+import (
+	"testing"
+)
+
+func TestDisplayOrNone(t *testing.T) {
+	str := "test"
+	num := 123
+	boolean := true
+	emptyStr := ""
+	var nilStr *string
+	var nilInt *int
+	var nilBool *bool
+	var nilInterface interface{}
+	var nonNilInterface interface{} = "wrapped"
+
+	emptyReplacement := "<none>"
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "string",
+			input:    str,
+			expected: str,
+		},
+		{
+			name:     "empty string",
+			input:    emptyStr,
+			expected: "",
+		},
+		{
+			name:     "nil *string",
+			input:    nilStr,
+			expected: emptyReplacement,
+		},
+		{
+			name:     "nil *int",
+			input:    nilInt,
+			expected: emptyReplacement,
+		},
+		{
+			name:     "*string",
+			input:    &str,
+			expected: str,
+		},
+		{
+			name:     "*int",
+			input:    &num,
+			expected: num,
+		},
+		{
+			name:     "boolean",
+			input:    boolean,
+			expected: boolean,
+		},
+		{
+			name:     "*boolean",
+			input:    &boolean,
+			expected: boolean,
+		},
+		{
+			name:     "nil *boolean",
+			input:    nilBool,
+			expected: emptyReplacement,
+		},
+		{
+			name:     "nil interface",
+			input:    nilInterface,
+			expected: emptyReplacement,
+		},
+		{
+			name:     "non-nil interface",
+			input:    nonNilInterface,
+			expected: nonNilInterface,
+		},
+		{
+			name:     "nil interface pointer",
+			input:    &nilInterface,
+			expected: emptyReplacement,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DisplayOrNone(tt.input)
+			if result != tt.expected {
+				t.Errorf("DisplayOrNone(%v) = %q; want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/pkg/utils/presenters/text_test.go
+++ b/internal/pkg/utils/presenters/text_test.go
@@ -12,15 +12,15 @@ func TestDisplayOrNone(t *testing.T) {
 	var nilStr *string
 	var nilInt *int
 	var nilBool *bool
-	var nilInterface interface{}
-	var nonNilInterface interface{} = "wrapped"
+	var nilInterface any
+	var nonNilInterface any = "wrapped"
 
 	emptyReplacement := "<none>"
 
 	tests := []struct {
 		name     string
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{
 			name:     "string",

--- a/internal/pkg/utils/style/typography.go
+++ b/internal/pkg/utils/style/typography.go
@@ -43,7 +43,7 @@ func InfoMsg(s string) string {
 	return applyStyle("[INFO] ", color.FgHiWhite) + s
 }
 
-func FailMsg(s string, a ...interface{}) string {
+func FailMsg(s string, a ...any) string {
 	return applyStyle("[ERROR] ", color.FgRed) + fmt.Sprintf(s, a...)
 }
 

--- a/internal/pkg/utils/text/json.go
+++ b/internal/pkg/utils/text/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-func InlineJSON(data interface{}) string {
+func InlineJSON(data any) string {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return ""
@@ -12,7 +12,7 @@ func InlineJSON(data interface{}) string {
 	return string(jsonData)
 }
 
-func IndentJSON(data interface{}) string {
+func IndentJSON(data any) string {
 	jsonData, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		return ""


### PR DESCRIPTION
## Problem
There are currently two entry points for creating indexes in the CLI. These commands were implemented at a time when Pinecone indexes had far less configuration options.

We'd like to collapse things into a single entrypoint for creating indexes: `pc index create`.

## Solution

- Add new `create.go` to the `index` cmd package. Implement business logic for deriving index type and doing some basic validation of arguments, along with instantiating the appropriate create index struct, and calling the appropriate methods through the SDK.
- Update the `index_description` presenter to handle newer index fields.
- Add unit test file to validate business logic - we currently have no unit or integration test coverage in the CLI repo, need to start somewhere and there's a bit of custom logic here.
- Pull in new dependency `heredoc` which is a commonly used package for writing things like Examples and Usage via cobra (see [kubectl](https://github.com/kubernetes/kubectl) and [GH cli](https://github.com/cli/cli), as examples).
- Add deprecation warnings to `create-pod` and `create-serverless` for now.
- General documentation, etc clean up.

## Type of Chang
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

You should now be able to call `pc index create [flags]` as a command:

```
# create a serverless index
$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1

# create a pod index
$ pc index create --name my-index --dimension 1536 --metric cosine --environment us-east-1-aws --pod-type p1.x1 --shards 2 --replicas 2

# create an integrated index
$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large --field_map text=chunk_text
```

