### PR TITLE
Refactor `GetAndSetAccessToken`, remove `pinecone` deprecation warning

### DIFF
--- a/cmd/pc/main.go
+++ b/cmd/pc/main.go
@@ -4,19 +4,9 @@ Copyright © 2025 Pinecone Systems, Inc.
 package main
 
 import (
-	"os"
-	"path/filepath"
-
 	cliRootCmd "github.com/pinecone-io/cli/internal/pkg/cli/command/root"
-	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
-	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
 func main() {
-	executableName := filepath.Base(os.Args[0])
-	if executableName == "pinecone" {
-		pcio.Fprintf(os.Stderr, "⚠️  Warning: The '%s' command is deprecated. Please use '%s' instead.", style.Code("pinecone"), style.Code("pc"))
-	}
-
 	cliRootCmd.Execute()
 }

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -41,18 +41,17 @@ func NewLoginCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := GetAndSetAccessToken(nil)
 			if err != nil {
+				log.Error().Err(err).Msg("Error fetching authentication token")
 				exit.Error(pcio.Errorf("error acquiring access token while logging in: %w", err))
-				return
 			}
 
 			// Parse token claims to get orgId
 			accessToken := secrets.OAuth2Token.Get()
 			claims, err := pc_oauth2.ParseClaimsUnverified(&accessToken)
 			if err != nil {
-				log.Error().Msg("Error parsing claims")
+				log.Error().Err(err).Msg("Error parsing authentication token claims")
 				msg.FailMsg("An auth token was fetched but an error occurred while parsing the token's claims: %s", err)
 				exit.Error(pcio.Errorf("error parsing claims from access token: %w", err))
-				return
 			}
 			msg.SuccessMsg("Logged in as " + style.Emphasis(claims.Email) + ". Defaulted to organization ID: " + style.Emphasis(claims.OrgId))
 
@@ -61,7 +60,6 @@ func NewLoginCmd() *cobra.Command {
 			if err != nil {
 				log.Error().Msg("Error fetching organizations")
 				exit.Error(pcio.Errorf("error fetching organizations: %w", err))
-				return
 			}
 
 			// target organization is whatever the JWT token's orgId is - defaults on first login currently
@@ -110,8 +108,6 @@ func NewLoginCmd() *cobra.Command {
 // If a token is successfully acquired it's set in the secrets store, and the user is considered logged in
 func GetAndSetAccessToken(orgId *string) error {
 	ctx := context.Background()
-
-	// da := pc_oauth2.DeviceAuth{}
 	a := pc_oauth2.Auth{}
 
 	// CSRF state
@@ -130,44 +126,52 @@ func GetAndSetAccessToken(orgId *string) error {
 		return err
 	}
 
+	// Spin up a local server to handle receiving the authorization code from auth0
+	codeCh := make(chan string)
+	serverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		code, err := ServeAuthCodeListener(serverCtx, csrfState)
+		if err != nil {
+			log.Error().Err(err).Msg("Error waiting for authorization")
+			codeCh <- ""
+			return
+		}
+		codeCh <- code
+	}()
+
 	pcio.Printf("Visit %s to authorize the CLI.\n", style.Underline(authURL))
 	pcio.Println()
+	pcio.Printf("Press %s to open the browser, or manually paste the URL above.\n", style.Code("[Enter]"))
 
-	pcio.Printf("Press %s to open the browser.\n", style.Code("[Enter]"))
-	_, err = bufio.NewReader(os.Stdin).ReadBytes('\n')
-	if err != nil {
-		exit.Error(pcio.Errorf("error reading input: %w", err))
-		return err
-	}
-
-	err = browser.OpenBrowser(authURL)
-	if err != nil {
-		exit.Error(pcio.Errorf("error opening browser: %w", err))
-		return err
-	}
-	pcio.Println("After you approve in the browser, it may take a few seconds for the next step to complete.")
-
-	// Spin up a local server to handle receiving the authorization code from auth0
-	code, err := ServeAuthCodeListener(ctx, csrfState)
-	if err != nil {
-		exit.Error(pcio.Errorf("error waiting for authorization: %w", err))
-		return err
-	}
-
-	// Exchange auth code for access token
-	if code != "" {
-		token, err := a.ExchangeAuthCode(ctx, verifier, code)
+	// open a thread to wait for [Enter] as input
+	go func() {
+		_, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
 		if err != nil {
-			exit.Error(pcio.Errorf("error exchanging auth code for access token: %w", err))
-			return err
+			log.Error().Err(err).Msg("stdin error: unable to open browser")
+			return
 		}
-		secrets.OAuth2Token.Set(token)
-		return nil
+		err = browser.OpenBrowser(authURL)
+		if err != nil {
+			log.Error().Err(err).Msg("error opening browser")
+			return
+		}
+	}()
+
+	// Wait for auth code and exchange for access token
+	code := <-codeCh
+	if code == "" {
+		return pcio.Error("error authenticating CLI and retrieving oauth2 access token")
 	}
 
-	// if we're here, it means we were not able to authenticate with the auth0 server
-	exit.Error(pcio.Errorf("error authenticating CLI and retrieving oauth2 access token"))
-	return pcio.Errorf("error authenticating CLI and retrieving oauth2 access token")
+	token, err := a.ExchangeAuthCode(ctx, verifier, code)
+	if err != nil {
+		exit.Error(pcio.Errorf("error exchanging auth code for access token: %w", err))
+	}
+
+	secrets.OAuth2Token.Set(token)
+	return nil
 }
 
 func ServeAuthCodeListener(ctx context.Context, csrfState string) (string, error) {

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -151,12 +151,17 @@ func GetAndSetAccessToken(orgId *string) error {
 		input := make(chan struct{})
 
 		go func() {
+			defer close(input)
 			_, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
 			if err != nil {
 				log.Error().Err(err).Msg("stdin error: unable to open browser")
 				return
 			}
-			input <- struct{}{}
+			select {
+			case input <- struct{}{}:
+			case <-ctx.Done():
+				return // context cancelled, no need to open browser
+			}
 		}()
 
 		select {


### PR DESCRIPTION
## Problem
We don't want to warn when people use `pinecone`, instead just allow `pinecone` and `pc` as valid entrypoints.

When calling `pc login` or `pc target`, the local authentication server is not properly listening for the auth response until the user presses `[Enter]`. This needs to be more robust to allow people to either copy-paste the URL themselves, or manually hitting `[Enter]` to authenticate.

## Solution
- Remove deprecation warning from `cmd/pc/main.go`.
- Refactor `GetAndSetAccessToken`: use separate goroutines to handle listening for the auth code response, and listening for the user to hit `[Enter]` through stdin. In both cases, the CLI should receive the code and continue authentication as expected.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Call `pc` or `pinecone` to work with the CLI - validate there is no warning displayed in either case.
Call `pc login` or `pc target`, and make sure you can either use `[Enter]` when prompted, cmd-clicking the URL, or manually copy-pasting the URL into your browser. In each case, the result should be the same, and you should see the org and project you're targeting:

```
pc login
Visit https://login.pinecone.io/oauth/authorize?.... to authorize the CLI.

Press [Enter] to open the browser, or manually paste the URL above.
[SUCCESS] Logged in as austin.d@pinecone.io. Defaulted to organization ID: -ORG_ID

[INFO] Target org set to pinecone-official.
[INFO] Target project set pinecone-proj.

Hint: Run pc target to change the target context.

Now try pc index -h to learn about index operations.
```
