### PR TITLE
Clean up Cobra `Example` blocks

### DIFF
--- a/internal/pkg/cli/command/apiKey/create.go
+++ b/internal/pkg/cli/command/apiKey/create.go
@@ -1,7 +1,6 @@
 package apiKey
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
@@ -31,9 +30,9 @@ func NewCreateApiKeyCmd() *cobra.Command {
 		Use:     "create",
 		Short:   "Create an API key for a specific project by ID or the target project",
 		GroupID: help.GROUP_API_KEYS.ID,
-		Example: heredoc.Doc(`
-		$ pc target -o "my-org" -p "my-project"
-		$ pc api-key create -n "my-key" 
+		Example: help.Examples(`
+			pc target -o "my-org" -p "my-project"
+			pc api-key create -n "my-key" 
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ac := sdk.NewPineconeAdminClient()

--- a/internal/pkg/cli/command/apiKey/delete.go
+++ b/internal/pkg/cli/command/apiKey/delete.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
@@ -29,9 +28,8 @@ func NewDeleteKeyCmd() *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete an API key by ID",
 		GroupID: help.GROUP_API_KEYS.ID,
-		Example: heredoc.Doc(`
-		$ pc target -o "my-org" -p "my-project"
-		$ pc api-key delete -i "api-key-id" 
+		Example: help.Examples(`
+			pc api-key delete -i "api-key-id" 
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ac := sdk.NewPineconeAdminClient()

--- a/internal/pkg/cli/command/apiKey/describe.go
+++ b/internal/pkg/cli/command/apiKey/describe.go
@@ -1,7 +1,6 @@
 package apiKey
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -24,8 +23,8 @@ func NewDescribeAPIKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Describe an API key by ID",
-		Example: heredoc.Doc(`
-		$ pc api-key describe -i <api-key-id>
+		Example: help.Examples(`
+			pc api-key describe -i <api-key-id>
 		`),
 		GroupID: help.GROUP_API_KEYS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/apiKey/list.go
+++ b/internal/pkg/cli/command/apiKey/list.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -29,9 +28,9 @@ func NewListKeysCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the API keys in a specific project by ID or the target project",
-		Example: heredoc.Doc(`
-		$ pc target -o "my-org" -p "my-project"
-		$ pc api-key list
+		Example: help.Examples(`
+			pc target -o "my-org" -p "my-project"
+			pc api-key list
 		`),
 		GroupID: help.GROUP_API_KEYS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/apiKey/update.go
+++ b/internal/pkg/cli/command/apiKey/update.go
@@ -1,7 +1,6 @@
 package apiKey
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -28,8 +27,8 @@ func NewUpdateAPIKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update an existing API key by ID with the specified configuration",
-		Example: heredoc.Doc(`
-		$ pc api-key update --id <api-key-id> --name <new-name> --roles <new-roles>
+		Example: help.Examples(`
+			pc api-key update --id <api-key-id> --name <new-name> --roles <new-roles>
 		`),
 		GroupID: help.GROUP_API_KEYS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/clear.go
+++ b/internal/pkg/cli/command/auth/clear.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -20,15 +19,15 @@ func NewClearCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clear",
 		Short: "Allows you to clear a configured service account (client ID and secret), or global API key",
-		Example: heredoc.Doc(`
-		# Clear configured service account credentials
-		$ pc auth clear --service-account
+		Example: help.Examples(`
+		    # Clear configured service account credentials
+		    pc auth clear --service-account
 
-		# Clear configured global API key
-		$ pc auth clear --global-api-key
+		    # Clear configured global API key
+		    pc auth clear --global-api-key
 
-		# Clear both configured service account credentials and global API key
-		$ pc auth clear --service-account --global-api-key
+			# Clear both configured service account credentials and global API key
+			pc auth clear --service-account --global-api-key
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/configure.go
+++ b/internal/pkg/cli/command/auth/configure.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
@@ -43,12 +42,12 @@ func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure authentication credentials for the Pinecone CLI",
-		Example: heredoc.Doc(`
-		# Configure service account credentials
-		$ pc auth configure --client-id <client-id> --client-secret <client-secret>
+		Example: help.Examples(`
+			# Configure service account credentials
+			pc auth configure --client-id <client-id> --client-secret <client-secret>
 
-		# Configure global API key
-		$ pc auth configure --global-api-key <global-api-key>
+			# Configure global API key
+			pc auth configure --global-api-key <global-api-key>
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/local_keys_list.go
+++ b/internal/pkg/cli/command/auth/local_keys_list.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
 	"github.com/pinecone-io/cli/internal/pkg/utils/text"
@@ -24,8 +24,8 @@ func NewListLocalKeysCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the project API keys that the CLI is currently managing in local state",
-		Example: heredoc.Doc(`
-		$ pc auth local-keys list --reveal
+		Example: help.Examples(`
+			pc auth local-keys list --reveal
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			managedKeys := secrets.GetManagedProjectKeys()

--- a/internal/pkg/cli/command/auth/local_keys_prune.go
+++ b/internal/pkg/cli/command/auth/local_keys_prune.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
@@ -34,17 +34,17 @@ func NewPruneLocalKeysCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prune",
 		Short: "Clean up project API keys that the CLI is managing",
-		Example: heredoc.Doc(`
-		# Prune all locally managed keys that the CLI has created
-		$ pc auth local-keys prune --origin cli --skip-confirmation
+		Example: help.Examples(`
+			# Prune all locally managed keys that the CLI has created
+			pc auth local-keys prune --origin cli --skip-confirmation
 
-		# Prune all locally managed keys that the user has created and stored
-		$ pc auth local-keys prune --origin user --skip-confirmation
+			# Prune all locally managed keys that the user has created and stored
+			pc auth local-keys prune --origin user --skip-confirmation
 
-		# Show a dry run plan of pruning all keys (origin defaults to "all")
-		# and then apply the changes
-		$ pc auth local-keys prune --dry-run --skip-confirmation
-		$ pc auth local-keys prune --skip-confirmation
+			# Show a dry run plan of pruning all keys (origin defaults to "all")
+			# and then apply the changes
+			pc auth local-keys prune --dry-run --skip-confirmation
+			pc auth local-keys prune --skip-confirmation
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runPruneLocalKeys(cmd.Context(), options)

--- a/internal/pkg/cli/command/auth/login.go
+++ b/internal/pkg/cli/command/auth/login.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"io"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/login"
 	"github.com/spf13/cobra"
@@ -13,9 +12,9 @@ import (
 func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to the Pinecone CLI",
-		Example: heredoc.Doc(`
-		$ pc auth login
+		Short: "Log in to the Pinecone CLI through the browser using your Pinecone account",
+		Example: help.Examples(`
+			pc auth login
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/logout.go
+++ b/internal/pkg/cli/command/auth/logout.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -12,9 +11,9 @@ import (
 func NewLogoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Delete all saved tokens and keys",
-		Example: heredoc.Doc(`
-		$ pc auth logout
+		Short: "Clear your authentication credentials, and delete all saved tokens and keys",
+		Example: help.Examples(`
+			pc auth logout
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/status.go
+++ b/internal/pkg/cli/command/auth/status.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"time"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/config"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
@@ -26,8 +25,8 @@ func NewCmdAuthStatus() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show the current authentication status of the Pinecone CLI",
-		Example: heredoc.Doc(`
-		$ pc auth status --json
+		Example: help.Examples(`
+			pc auth status --json
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/whoami.go
+++ b/internal/pkg/cli/command/auth/whoami.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
@@ -16,8 +15,8 @@ func NewWhoAmICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "See the current logged in user",
-		Example: heredoc.Doc(`
-		$ pc auth whoami
+		Example: help.Examples(`
+			pc auth whoami
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/collection/create.go
+++ b/internal/pkg/cli/command/collection/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -27,6 +28,9 @@ func NewCreateCollectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a collection from a pod-based index",
+		Example: help.Examples(`
+			pc collection create --name my-collection --source my-index
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			pc := sdk.NewPineconeClient()
 			ctx := context.Background()

--- a/internal/pkg/cli/command/collection/delete.go
+++ b/internal/pkg/cli/command/collection/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
@@ -21,6 +22,9 @@ func NewDeleteCollectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a collection",
+		Example: help.Examples(`
+			pc collection delete --name my-collection
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
 			pc := sdk.NewPineconeClient()

--- a/internal/pkg/cli/command/collection/describe.go
+++ b/internal/pkg/cli/command/collection/describe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -23,6 +24,9 @@ func NewDescribeCollectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Get information on a collection",
+		Example: help.Examples(`
+			pc collection describe --name my-collection
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
 			pc := sdk.NewPineconeClient()

--- a/internal/pkg/cli/command/collection/list.go
+++ b/internal/pkg/cli/command/collection/list.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
@@ -28,6 +29,9 @@ func NewListCollectionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "See the list of collections in your project",
+		Example: help.Examples(`
+			pc collection list
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			pc := sdk.NewPineconeClient()
 			ctx := context.Background()

--- a/internal/pkg/cli/command/config/get_api_key.go
+++ b/internal/pkg/cli/command/config/get_api_key.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
 	"github.com/spf13/cobra"
@@ -11,6 +12,10 @@ func NewGetApiKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-api-key",
 		Short: "Get the current API key configured for the Pinecone CLI",
+		Example: help.Examples(`
+		    pc config set-color true
+		    pc config set-color false
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			apiKey := secrets.GlobalApiKey.Get()
 			pcio.Printf("Currently configured global API Key: %s", presenters.MaskHeadTail(apiKey, 4, 4))

--- a/internal/pkg/cli/command/config/set_api_key.go
+++ b/internal/pkg/cli/command/config/set_api_key.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 	"github.com/spf13/cobra"
@@ -10,12 +11,15 @@ import (
 func NewSetApiKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-api-key",
-		Short: "Manually set the API key for the Pinecone CLI",
+		Short: "Manually set the global API key for the Pinecone CLI",
+		Example: help.Examples(`
+		    pc config set-api-key <api-key>
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			newApiKey := args[0]
 			secrets.GlobalApiKey.Set(newApiKey)
 			msg.SuccessMsg("Config property %s updated.", style.Emphasis("api_key"))
-			msg.InfoMsg("To clear saved keys, run %s.", style.Code("pc logout"))
+			msg.InfoMsg("To clear the global API key, run %s.", style.Code("pc auth clear --global-api-key"))
 		},
 	}
 

--- a/internal/pkg/cli/command/config/set_color.go
+++ b/internal/pkg/cli/command/config/set_color.go
@@ -14,10 +14,10 @@ func NewSetColorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-color",
 		Short: "Configure whether the CLI prints output with color",
-		Example: help.Examples([]string{
-			"pc config set-color true",
-			"pc config set-color false",
-		}),
+		Example: help.Examples(`
+			pc config set-color true
+			pc config set-color false
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				msg.FailMsg("Please provide a value for color. Accepted values are 'true', 'false'")

--- a/internal/pkg/cli/command/config/set_environment.go
+++ b/internal/pkg/cli/command/config/set_environment.go
@@ -18,10 +18,10 @@ func NewSetEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-environment <production|staging>",
 		Short: "Configure the environment (production or staging)",
-		Example: help.Examples([]string{
-			"pc config set-environment production",
-			"pc config set-environment staging",
-		}),
+		Example: help.Examples(`
+			pc config set-environment production
+			pc config set-environment staging
+		`),
 		Hidden: false,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {

--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/text"
 	"github.com/spf13/cobra"
@@ -17,7 +16,7 @@ func NewIndexCmd() *cobra.Command {
 		Use:   "index",
 		Short: "Work with indexes",
 		Long:  helpText,
-		Example: heredoc.Doc(`
+		Example: help.Examples(`
 			$ pc index list
 			$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
 			$ pc index describe --name my-index

--- a/internal/pkg/cli/command/index/configure.go
+++ b/internal/pkg/cli/command/index/configure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -27,9 +28,11 @@ func NewConfigureIndexCmd() *cobra.Command {
 	options := configureIndexOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "configure",
-		Short:   "Configure an existing index with the specified configuration",
-		Example: "",
+		Use:   "configure",
+		Short: "Configure an existing index with the specified configuration",
+		Example: help.Examples(`
+			pc index configure --name my-index --deletion-protection enabled
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runConfigureIndexCmd(options)
 		},

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/docslinks"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
@@ -78,15 +79,15 @@ func NewCreateIndexCmd() *cobra.Command {
 		For detailed documentation, see:
 		%s
 		`, style.Code("pc index create"), style.URL(docslinks.DocsIndexCreate)),
-		Example: heredoc.Doc(`
-		# create a serverless index
-		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
+		Example: help.Examples(`
+			# create a serverless index
+			pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
 
-		# create a pod index
-		$ pc index create --name my-index --dimension 1536 --metric cosine --environment us-east-1-aws --pod-type p1.x1 --shards 2 --replicas 2
+			# create a pod index
+			pc index create --name my-index --dimension 1536 --metric cosine --environment us-east-1-aws --pod-type p1.x1 --shards 2 --replicas 2
 
-		# create an integrated index
-		$ pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large --field_map text=chunk_text
+			# create an integrated index
+			pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1 --model multilingual-e5-large --field_map text=chunk_text
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreateIndexCmd(options)

--- a/internal/pkg/cli/command/index/create_pod.go
+++ b/internal/pkg/cli/command/index/create_pod.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -34,9 +35,11 @@ func NewCreatePodCmd() *cobra.Command {
 	options := createPodOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "create-pod",
-		Short:   "Create a pod index with the specified configuration",
-		Example: "",
+		Use:   "create-pod",
+		Short: "Create a pod index with the specified configuration",
+		Example: help.Examples(`
+			pc index create-pod --name my-index --dimension 1536 --metric cosine --environment us-east-1-aws --pod-type p1.x1 --shards 2 --replicas 2
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreatePodCmd(options)
 		},

--- a/internal/pkg/cli/command/index/create_serverless.go
+++ b/internal/pkg/cli/command/index/create_serverless.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -32,6 +33,9 @@ func NewCreateServerlessCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-serverless",
 		Short: "Create a serverless index with the specified configuration",
+		Example: help.Examples(`
+			pc index create-serverless --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreateServerlessCmd(options)
 		},

--- a/internal/pkg/cli/command/index/delete.go
+++ b/internal/pkg/cli/command/index/delete.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
@@ -21,6 +22,9 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete an index",
+		Example: help.Examples(`
+			pc index delete --name my-index
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
 			pc := sdk.NewPineconeClient()

--- a/internal/pkg/cli/command/index/describe.go
+++ b/internal/pkg/cli/command/index/describe.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
@@ -24,6 +25,9 @@ func NewDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Get configuration and status information for an index",
+		Example: help.Examples(`
+			pc index describe --name my-index
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			pc := sdk.NewPineconeClient()
 

--- a/internal/pkg/cli/command/index/list.go
+++ b/internal/pkg/cli/command/index/list.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
@@ -27,6 +28,9 @@ func NewListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "See the list of indexes in the targeted project",
+		Example: help.Examples(`
+			pc index list
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			pc := sdk.NewPineconeClient()
 			ctx := context.Background()

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"io"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/login"
 	"github.com/spf13/cobra"
@@ -14,8 +13,8 @@ func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the Pinecone CLI through the browser using your Pinecone account",
-		Example: heredoc.Doc(`
-		$ pc login
+		Example: help.Examples(`
+			pc login
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/login/whoami.go
+++ b/internal/pkg/cli/command/login/whoami.go
@@ -1,7 +1,6 @@
 package login
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/log"
@@ -16,8 +15,8 @@ func NewWhoAmICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "See the current logged in user",
-		Example: heredoc.Doc(`
-		$ pc whoami
+		Example: help.Examples(`
+			pc whoami
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/logout/logout.go
+++ b/internal/pkg/cli/command/logout/logout.go
@@ -1,7 +1,6 @@
 package logout
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -13,8 +12,8 @@ func NewLogoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Clear your authentication credentials, and delete all saved tokens and keys",
-		Example: heredoc.Doc(`
-		$ pc logout
+		Example: help.Examples(`
+			pc logout
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/organization/delete.go
+++ b/internal/pkg/cli/command/organization/delete.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -29,9 +28,9 @@ func NewDeleteOrganizationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete an organization by ID",
-		Example: heredoc.Doc(`
-		$ pc organization delete -i <organization-id>
-		$ pc organization delete -i <organization-id> --skip-confirmation
+		Example: help.Examples(`
+			pc organization delete --id <organization-id>
+			pc organization delete --id <organization-id> --skip-confirmation
 		`),
 		GroupID: help.GROUP_ORGANIZATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/organization/describe.go
+++ b/internal/pkg/cli/command/organization/describe.go
@@ -1,7 +1,6 @@
 package organization
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -25,8 +24,8 @@ func NewDescribeOrganizationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Describe an organization by ID or the target organization",
-		Example: heredoc.Doc(`
-		$ pc organization describe -i <organization-id>
+		Example: help.Examples(`
+			pc organization describe --id <organization-id>
 		`),
 		GroupID: help.GROUP_ORGANIZATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/organization/list.go
+++ b/internal/pkg/cli/command/organization/list.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
@@ -27,8 +26,8 @@ func NewListOrganizationsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all organizations available to the currently authenticated user",
-		Example: heredoc.Doc(`
-		$ pc organization list
+		Example: help.Examples(`
+			pc organization list
 		`),
 		GroupID: help.GROUP_ORGANIZATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/organization/update.go
+++ b/internal/pkg/cli/command/organization/update.go
@@ -1,7 +1,6 @@
 package organization
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -28,8 +27,8 @@ func NewUpdateOrganizationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update an existing organization by ID or the target organization with the specified configuration",
-		Example: heredoc.Doc(`
-		$ pc organization update -i <organization-id> --n <new-name>
+		Example: help.Examples(`
+			pc organization update --id <organization-id> --name <new-name>
 		`),
 		GroupID: help.GROUP_ORGANIZATIONS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/project/create.go
+++ b/internal/pkg/cli/command/project/create.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -32,9 +31,9 @@ func NewCreateProjectCmd() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a project for the target organization determined by user credentials",
 		GroupID: help.GROUP_PROJECTS.ID,
-		Example: heredoc.Doc(`
-		$ pc target -o "my-organization-name"
-		$ pc project create --name "demo-project" --max-pods 10 --force-encryption
+		Example: help.Examples(`
+			pc target -o "my-organization-name"
+			pc project create --name "demo-project" --max-pods 10 --force-encryption
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ac := sdk.NewPineconeAdminClient()

--- a/internal/pkg/cli/command/project/delete.go
+++ b/internal/pkg/cli/command/project/delete.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -30,8 +29,8 @@ func NewDeleteProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a specific project by ID or the target project",
-		Example: heredoc.Doc(`
-		$ pc project delete -i <project-id>
+		Example: help.Examples(`
+			pc project delete --id <project-id>
 		`),
 		GroupID: help.GROUP_PROJECTS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/project/describe.go
+++ b/internal/pkg/cli/command/project/describe.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -28,8 +27,8 @@ func NewDescribeProjectCmd() *cobra.Command {
 		Use:     "describe",
 		Short:   "Describe a specific project by ID or the target project",
 		GroupID: help.GROUP_PROJECTS.ID,
-		Example: heredoc.Doc(`
-		$ pc project describe -i <project-id>
+		Example: help.Examples(`
+			pc project describe --id <project-id>
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ac := sdk.NewPineconeAdminClient()

--- a/internal/pkg/cli/command/project/list.go
+++ b/internal/pkg/cli/command/project/list.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
@@ -30,8 +29,8 @@ func NewListProjectsCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "list all projects in the organization available to the authenticated user",
 		GroupID: help.GROUP_PROJECTS.ID,
-		Example: heredoc.Doc(`
-		$ pc project list
+		Example: help.Examples(`
+			pc project list
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			ac := sdk.NewPineconeAdminClient()

--- a/internal/pkg/cli/command/project/update.go
+++ b/internal/pkg/cli/command/project/update.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
@@ -32,8 +31,8 @@ func NewUpdateProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update an existing project by ID or the target project with the specified configuration",
-		Example: heredoc.Doc(`
-		$ pc project update --id <project-id> --name <new-name> --max-pods <new-max-pods>
+		Example: help.Examples(`
+			pc project update --id <project-id> --name <new-name> --max-pods <new-max-pods>
 		`),
 		GroupID: help.GROUP_PROJECTS.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -41,11 +41,11 @@ func init() {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			pcio.SetQuiet(globalOptions.quiet)
 		},
-		Example: help.Examples([]string{
-			"pc login",
-			"pc target",
-			"pc index create-serverless --help",
-		}),
+		Example: help.Examples(`
+		    pc login
+			pc target
+			pc index create-serverless --help
+		`),
 		Long: pcio.Sprintf(`pc is a CLI tool for managing your Pinecone resources
 
 Get started by logging in with

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -50,9 +50,19 @@ func NewTargetCmd() *cobra.Command {
 	options := TargetCmdOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "target <flags>",
-		Short:   "Set context for the CLI",
-		Long:    targetHelp,
+		Use:   "target <flags>",
+		Short: "Set context for the CLI",
+		Long:  targetHelp,
+		Example: help.Examples(`
+			# Interactively target from available organizations and projects
+			pc target
+
+			# Target an organization and project by name
+			pc target -o <organization-name> -p <project-name>
+
+			# Target a project by name
+			pc target -p <project-name>
+		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Debug().

--- a/internal/pkg/cli/command/version/version.go
+++ b/internal/pkg/cli/command/version/version.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/pinecone-io/cli/internal/build"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,9 @@ func NewVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "See version information for the CLI",
+		Example: help.Examples(`
+			pc version
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			pcio.Printf("Version: %s\n", build.Version)
 			pcio.Printf("SHA: %s\n", build.Commit)

--- a/internal/pkg/utils/help/examples.go
+++ b/internal/pkg/utils/help/examples.go
@@ -3,13 +3,43 @@ package help
 import (
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/pinecone-io/cli/internal/pkg/utils/style"
 )
 
-func Examples(examples []string) string {
-	const pad = "  "
-	for i := range examples {
-		examples[i] = pad + style.CodeWithPrompt(examples[i])
+const pad = "  "
+
+// Examples normalizes a Cobra example block.
+// - Accepts a multi-line string with possible indentation
+// - De-indents with heredoc.Doc, trims leading/trailing whitespace, preserves interior blank lines
+// - Left-indents each line and applies styles.CodeWithPrompt for command lines
+func Examples(examples string) string {
+	block := strings.TrimSpace(heredoc.Doc(examples))
+	if block == "" {
+		return ""
 	}
-	return strings.Join(examples, "\n")
+
+	lines := strings.Split(block, "\n")
+	out := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		line := strings.TrimRight(line, " \t\r")
+		if strings.TrimSpace(line) == "" {
+			out = append(out, "")
+			continue
+		}
+
+		trimmed := strings.TrimLeft(line, " \t")
+
+		// Comment line
+		if strings.HasPrefix(trimmed, "#") {
+			out = append(out, pad+style.Faint(trimmed))
+			continue
+		}
+
+		// Command line
+		out = append(out, pad+style.CodeWithPrompt(trimmed))
+	}
+
+	return strings.Join(out, "\n")
 }

--- a/internal/pkg/utils/style/color.go
+++ b/internal/pkg/utils/style/color.go
@@ -17,6 +17,10 @@ func applyStyle(s string, c color.Attribute) string {
 	return colored(s)
 }
 
+func Faint(s string) string {
+	return applyStyle(s, color.Faint)
+}
+
 func CodeWithPrompt(s string) string {
 	return (applyStyle("$ ", color.Faint) + applyColor(s, color.New(color.FgMagenta, color.Bold)))
 }


### PR DESCRIPTION
## Problem
We're working on improving the overall documentation experience around the CLI. One area that could use some attention are our `Example` blocks in our `cobra.Command` configurations. We're inconsistently using utilities in different commands, some commands need examples, etc. These are important because they're part of the self-documenting nature of the CLI, and are used when calling `--help` against a command, or generating man pages.

## Solution
- Improve the help.Examples helper function, move heredoc inside of it so we get easier expression at callsite. 
- Make sure our example commands are consistent in syntax and style. Update commands that need examples.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Pull this branch down, build the binary with goreleaser, and run commands with `--help` to validate the output.
