### PR TITLE
Add more robust `Long` help text for commands

### DIFF
--- a/internal/pkg/cli/command/apiKey/cmd.go
+++ b/internal/pkg/cli/command/apiKey/cmd.go
@@ -5,10 +5,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	apiKeyHelp = help.Long(`
+		Work with API keys for a specific Pinecone project. Each Pinecone project has
+		one or more API keys. In order to make requests to the Pinecone API, you need 
+		to authenticate with an API key.
+
+		In order to work with resources outside of the admin API through the CLI, an 
+		API key is required. You can set a global API key using pc auth configure --global-api-key, 
+		or store an API key using pc api-key create --store. If you do not explicitly provide a key,
+		the CLI will create a managed key for the target project. These API keys can be managed
+		using pc auth local-keys.
+
+		See: https://docs.pinecone.io/guides/projects/manage-api-keys
+	`)
+)
+
 func NewAPIKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "api-key <command>",
-		Short:   "Manage API keys for a project",
+		Short:   "Work with API keys for a specific Pinecone project",
+		Long:    apiKeyHelp,
 		GroupID: help.GROUP_ADMIN.ID,
 	}
 

--- a/internal/pkg/cli/command/apiKey/create.go
+++ b/internal/pkg/cli/command/apiKey/create.go
@@ -79,7 +79,7 @@ func NewCreateApiKeyCmd() *cobra.Command {
 				json := text.IndentJSON(keyWithSecret)
 				pcio.Println(json)
 			} else {
-				msg.SuccessMsg("API Key %s created successfully.\n", style.Emphasis(keyWithSecret.Key.Name))
+				msg.SuccessMsg("API key %s created successfully.\n", style.Emphasis(keyWithSecret.Key.Name))
 				presenters.PrintDescribeAPIKeyWithSecretTable(keyWithSecret)
 			}
 

--- a/internal/pkg/cli/command/apiKey/create.go
+++ b/internal/pkg/cli/command/apiKey/create.go
@@ -23,12 +23,31 @@ type CreateApiKeyOptions struct {
 	json      bool
 }
 
+var (
+	createHelp = help.Long(`
+		Create an API key for a specific project by ID. If no project ID is provided,
+		the CLI will create a key for the currently targeted project. If you provide the 
+		--store flag, the key will be stored locally for use by the CLI when accessing control
+		and data plane resources.
+
+		If no roles are provided for the new key it will default to having the 'ProjectEditor' role.
+		Roles: 
+			- 'ProjectEditor'
+			- 'ProjectViewer'
+			- 'ControlPlaneEditor'
+			- 'ControlPlaneViewer'
+			- 'DataPlaneEditor'
+			- 'DataPlaneViewer'
+	`)
+)
+
 func NewCreateApiKeyCmd() *cobra.Command {
 	options := CreateApiKeyOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "create",
-		Short:   "Create an API key for a specific project by ID or the target project",
+		Short:   "Create an API key for a specific project by ID",
+		Long:    createHelp,
 		GroupID: help.GROUP_API_KEYS.ID,
 		Example: help.Examples(`
 		    # Create a new API key for the target project

--- a/internal/pkg/cli/command/apiKey/delete.go
+++ b/internal/pkg/cli/command/apiKey/delete.go
@@ -21,12 +21,22 @@ type DeleteApiKeyOptions struct {
 	skipConfirmation bool
 }
 
+var (
+	deleteHelp = help.Long(`
+		Delete an API key by ID. 
+		
+		Any integrations using this API key will stop working.
+		If you have stored the key locally, it will also be deleted from your local storage.
+	`)
+)
+
 func NewDeleteKeyCmd() *cobra.Command {
 	options := DeleteApiKeyOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "Delete an API key by ID",
+		Long:    deleteHelp,
 		GroupID: help.GROUP_API_KEYS.ID,
 		Example: help.Examples(`
 			pc api-key delete --id "api-key-id" 

--- a/internal/pkg/cli/command/apiKey/delete.go
+++ b/internal/pkg/cli/command/apiKey/delete.go
@@ -71,8 +71,8 @@ func NewDeleteKeyCmd() *cobra.Command {
 }
 
 func confirmDeleteApiKey(apiKeyName string) {
-	msg.WarnMsg("This operation will delete API Key %s from project %s.", style.Emphasis(apiKeyName), style.Emphasis(state.TargetProj.Get().Name))
-	msg.WarnMsg("Any integrations you have that auth with this API Key will stop working.")
+	msg.WarnMsg("This operation will delete API key %s from project %s.", style.Emphasis(apiKeyName), style.Emphasis(state.TargetProj.Get().Name))
+	msg.WarnMsg("Any integrations you have that auth with this API key will stop working.")
 	msg.WarnMsg("This action cannot be undone.")
 
 	// Prompt the user

--- a/internal/pkg/cli/command/apiKey/list.go
+++ b/internal/pkg/cli/command/apiKey/list.go
@@ -27,7 +27,7 @@ func NewListKeysCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List the API keys in a specific project by ID or the target project",
+		Short: "List the API keys in a specific project by ID, or the target project",
 		Example: help.Examples(`
 			# List API keys for the target project
 			pc target --org "org-name" --project "project-name"

--- a/internal/pkg/cli/command/apiKey/update.go
+++ b/internal/pkg/cli/command/apiKey/update.go
@@ -14,11 +14,9 @@ import (
 
 type UpdateAPIKeyOptions struct {
 	apiKeyId string
-
-	name  string
-	roles []string
-
-	json bool
+	name     string
+	roles    []string
+	json     bool
 }
 
 func NewUpdateAPIKeyCmd() *cobra.Command {
@@ -26,7 +24,7 @@ func NewUpdateAPIKeyCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update an existing API key by ID with the specified configuration",
+		Short: "Update an existing API key by ID",
 		Example: help.Examples(`
 			pc api-key update --id "api-key-id" --name "updated-name" --roles "ProjectEditor"
 		`),

--- a/internal/pkg/cli/command/auth/clear.go
+++ b/internal/pkg/cli/command/auth/clear.go
@@ -18,7 +18,7 @@ func NewClearCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "clear",
-		Short: "Allows you to clear a configured service account (client ID and secret), or global API key",
+		Short: "Allows you to clear a configured service account (client ID & secret), or global API key",
 		Example: help.Examples(`
 		    # Clear configured service account credentials
 		    pc auth clear --service-account
@@ -39,7 +39,7 @@ func NewClearCmd() *cobra.Command {
 			if options.serviceAccount {
 				secrets.ClientId.Clear()
 				secrets.ClientSecret.Clear()
-				msg.SuccessMsg("Service account (client ID and secret) cleared")
+				msg.SuccessMsg("Service account (client ID & secret) cleared")
 			}
 
 			if options.globalAPIKey {
@@ -49,7 +49,7 @@ func NewClearCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&options.serviceAccount, "service-account", false, "Clear the configured service account (client ID and secret)")
+	cmd.Flags().BoolVar(&options.serviceAccount, "service-account", false, "Clear the configured service account (client ID & secret)")
 	cmd.Flags().BoolVar(&options.globalAPIKey, "global-api-key", false, "Clear the configured global API key")
 
 	return cmd

--- a/internal/pkg/cli/command/auth/cmd.go
+++ b/internal/pkg/cli/command/auth/cmd.go
@@ -5,10 +5,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	authHelp = help.Long(`
+		Authenticate and manage credentials for the Pinecone CLI.
+
+		There are three ways of authenticating with Pinecone through the CLI:
+		through a web browser with user login, using a service account, or 
+		configuring a global API key.
+
+		User login and service account authentication provide access to the admin API,
+		allowing you to work with projects, API keys, and organizations. You will also
+		be able to configure a target organization and project context, which will be
+		used for control and data plane operations.
+		
+		Configuring a global API key overrides any target context, and allows 
+		access to control and data plane resources directly. Global API keys
+		do not have access to admin API resources.
+
+		See: https://docs.pinecone.io/reference/tools/cli-authentication
+	`)
+)
+
 func NewAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "auth <command>",
-		Short:   "Log in and manage authentication credentials for the CLI",
+		Short:   "Authenticate and manage credentials for the Pinecone CLI",
 		GroupID: help.GROUP_AUTH.ID,
 	}
 

--- a/internal/pkg/cli/command/auth/configure.go
+++ b/internal/pkg/cli/command/auth/configure.go
@@ -36,12 +36,26 @@ type ConfigureCmdOptions struct {
 	json                bool
 }
 
+var (
+	configureHelp = help.Long(`
+		Configure authentication credentials for the Pinecone CLI.
+
+		You can configure a service account (client ID & secret) or a global API key. Service
+		accounts automatically target an organization and will prompt to select a project, which
+		can be overridden with the --project-id flag. Configuring a service account will clear
+		any existing user login credentials.
+
+		A global API key overrides any target organization/project context. 
+	`)
+)
+
 func NewConfigureCmd() *cobra.Command {
 	options := ConfigureCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure authentication credentials for the Pinecone CLI",
+		Long:  configureHelp,
 		Example: help.Examples(`
 			# Configure service account credentials
 			pc auth configure --client-id "client-id" --client-secret "client-secret"

--- a/internal/pkg/cli/command/auth/local_keys.go
+++ b/internal/pkg/cli/command/auth/local_keys.go
@@ -5,10 +5,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	localKeysHelp = help.Long(`
+		Work with API keys that the CLI is managing in local state.
+
+		When authenticated with user login or a service account, the CLI automatically
+		creates and manages API keys for control and data plane operations. This happens
+		transparently, the first time you run a control/data plane command (pc index list).
+		You can also create a new key yourself and store it as a managed key using
+		pc api-key create --store.
+
+		See: https://docs.pinecone.io/reference/tools/cli-authentication#managed-keys
+	`)
+)
+
 func NewLocalKeysCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "local-keys <command>",
 		Short:   "Work with API keys that the CLI is managing in local state",
+		Long:    localKeysHelp,
 		GroupID: help.GROUP_AUTH.ID,
 	}
 

--- a/internal/pkg/cli/command/auth/local_keys_list.go
+++ b/internal/pkg/cli/command/auth/local_keys_list.go
@@ -18,12 +18,24 @@ type ListLocalKeysCmdOptions struct {
 	json   bool
 }
 
+var (
+	listHelp = help.Long(`
+		List the project API keys that the CLI is currently managing in local state.
+
+		The CLI will only store one API key per project, as needed. API key values will
+		be obscured in the output by default.
+
+		See: https://docs.pinecone.io/reference/tools/cli-authentication#identifying-managed-keys
+	`)
+)
+
 func NewListLocalKeysCmd() *cobra.Command {
 	options := ListLocalKeysCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the project API keys that the CLI is currently managing in local state",
+		Long:  listHelp,
 		Example: help.Examples(`
 			pc auth local-keys list --reveal
 		`),

--- a/internal/pkg/cli/command/auth/local_keys_prune.go
+++ b/internal/pkg/cli/command/auth/local_keys_prune.go
@@ -166,9 +166,9 @@ func createKeysMap(keys []*pinecone.APIKey) map[string]struct{} {
 }
 
 func confirmPruneKeys(plan []planItem, options PruneLocalKeysCmdOptions) (bool, error) {
-	msg.WarnMsg("This operation will delete the following API Keys:")
+	msg.WarnMsg("This operation will delete the following API keys:")
 	printDryRunPlan(plan, options)
-	msg.WarnMsg("Any integrations you have that auth with these API Keys will stop working.")
+	msg.WarnMsg("Any integrations you have that auth with these API keys will stop working.")
 	msg.WarnMsg("This action cannot be undone.")
 
 	// Prompt the user

--- a/internal/pkg/cli/command/auth/local_keys_prune.go
+++ b/internal/pkg/cli/command/auth/local_keys_prune.go
@@ -28,12 +28,29 @@ type PruneLocalKeysCmdOptions struct {
 	json             bool
 }
 
+var (
+	pruneHelp = help.Long(`
+		Delete project API keys that the CLI is managing in local state.
+
+		This operation will remove managed keys from local storage, and delete them
+		from Pinecone servers. Any integrations you have that authenticate with these
+		keys outside of the CLI will stop working.
+
+		By default, prune will delete all project keys that the CLI is managing, whether
+		they were created by the CLI or the user. You can filter the operation by 
+		project ID or key origin. Options for origin are: 'cli', 'user', or 'all' (default).
+
+		See: https://docs.pinecone.io/reference/tools/cli-authentication#deleting-api-keys
+	`)
+)
+
 func NewPruneLocalKeysCmd() *cobra.Command {
 	options := PruneLocalKeysCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "prune",
-		Short: "Clean up project API keys that the CLI is managing",
+		Short: "Delete project API keys that the CLI is managing in local state",
+		Long:  pruneHelp,
 		Example: help.Examples(`
 			# Prune all locally managed keys that the CLI has created
 			pc auth local-keys prune --origin cli --skip-confirmation

--- a/internal/pkg/cli/command/auth/login.go
+++ b/internal/pkg/cli/command/auth/login.go
@@ -9,10 +9,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	loginHelp = help.Long(`
+		Authenticate with Pinecone via user login in a web browser.
+
+		After logging in, a target organization and project context will be automatically set.
+		You can set a new target organization or project using pc target before accessing control
+		and data plane resources.
+	`)
+)
+
 func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to the Pinecone CLI through the browser using your Pinecone account",
+		Short: "Authenticate with Pinecone via user login in a web browser",
+		Long:  loginHelp,
 		Example: help.Examples(`
 			pc auth login
 		`),

--- a/internal/pkg/cli/command/auth/logout.go
+++ b/internal/pkg/cli/command/auth/logout.go
@@ -11,7 +11,7 @@ import (
 func NewLogoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Clear your authentication credentials, and delete all saved tokens and keys",
+		Short: "Clear your authentication credentials, and remove all locally stored API keys",
 		Example: help.Examples(`
 			pc auth logout
 		`),

--- a/internal/pkg/cli/command/auth/status.go
+++ b/internal/pkg/cli/command/auth/status.go
@@ -24,7 +24,7 @@ func NewCmdAuthStatus() *cobra.Command {
 	options := AuthStatusCmdOptions{}
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show the current authentication status of the Pinecone CLI",
+		Short: "Show the current authentication configuration for the Pinecone CLI",
 		Example: help.Examples(`
 			pc auth status --json
 		`),

--- a/internal/pkg/cli/command/collection/cmd.go
+++ b/internal/pkg/cli/command/collection/cmd.go
@@ -5,20 +5,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	collectionHelp = help.Long(`
+		A collection is a static copy of an index. It is a non-queryable 
+		representation of a set of vectors and metadata. You can create a 
+		collection from an index, and you can create a new index from a 
+		collection. 
+		
+		This new index can differ from the original source index: the 
+		new index can have a different number of pods, a different pod type, 
+		or a different similarity metric.
+	`)
+)
+
 func NewCollectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "collection <command>",
-		Short: "Work with collections",
-		Long: help.Long(`
-			A collection is a static copy of an index. It is a non-queryable 
-			representation of a set of vectors and metadata. You can create a 
-			collection from an index, and you can create a new index from a 
-			collection. 
-			
-			This new index can differ from the original source index: the 
-			new index can have a different number of pods, a different pod type, 
-			or a different similarity metric.
-		`),
+		Use:     "collection <command>",
+		Short:   "Work with collections",
+		Long:    collectionHelp,
 		GroupID: help.GROUP_VECTORDB.ID,
 	}
 

--- a/internal/pkg/cli/command/config/cmd.go
+++ b/internal/pkg/cli/command/config/cmd.go
@@ -6,12 +6,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	configHelp = help.LongF(`
+		Manage configuration for the Pinecone CLI.
+
+		Configuration for this CLI is stored in a file called config.yaml in the %s directory.
+	`, configuration.NewConfigLocations().ConfigPath)
+)
+
 func NewConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config <command>",
 		Short: "Manage configuration for the Pinecone CLI",
-		Long: help.LongF(`Configuration for this CLI is stored in a file called config.yaml in the %s directory.`,
-			configuration.NewConfigLocations().ConfigPath),
+		Long:  configHelp,
 	}
 
 	cmd.AddCommand(NewSetColorCmd())

--- a/internal/pkg/cli/command/config/get_api_key.go
+++ b/internal/pkg/cli/command/config/get_api_key.go
@@ -8,19 +8,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type GetAPIKeyCmdOptions struct {
+	reveal bool
+}
+
 func NewGetApiKeyCmd() *cobra.Command {
+	options := GetAPIKeyCmdOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "get-api-key",
-		Short: "Get the current API key configured for the Pinecone CLI",
+		Short: "Get the current global API key configured for the Pinecone CLI",
 		Example: help.Examples(`
-		    pc config set-color true
-		    pc config set-color false
+		    pc config get-api-key
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			apiKey := secrets.GlobalApiKey.Get()
-			pcio.Printf("Currently configured global API key: %s", presenters.MaskHeadTail(apiKey, 4, 4))
+			if !options.reveal {
+				apiKey = presenters.MaskHeadTail(apiKey, 4, 4)
+			}
+			pcio.Printf("Currently configured global API key: %s", apiKey)
 		},
 	}
+
+	cmd.Flags().BoolVar(&options.reveal, "reveal", false, "Reveal the full API key value in the output")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/config/get_api_key.go
+++ b/internal/pkg/cli/command/config/get_api_key.go
@@ -18,7 +18,7 @@ func NewGetApiKeyCmd() *cobra.Command {
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			apiKey := secrets.GlobalApiKey.Get()
-			pcio.Printf("Currently configured global API Key: %s", presenters.MaskHeadTail(apiKey, 4, 4))
+			pcio.Printf("Currently configured global API key: %s", presenters.MaskHeadTail(apiKey, 4, 4))
 		},
 	}
 

--- a/internal/pkg/cli/command/config/set_api_key.go
+++ b/internal/pkg/cli/command/config/set_api_key.go
@@ -8,10 +8,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	setAPIKeyHelp = help.Long(`
+		Configure the global API key for the CLI.
+
+		This will override any target context set through user login or service account credentials.
+		You can clear the global API key by running pc auth clear --global-api-key.
+	`)
+)
+
 func NewSetApiKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-api-key",
-		Short: "Manually set the global API key for the Pinecone CLI",
+		Short: "Configure the global API key for the CLI",
+		Long:  setAPIKeyHelp,
 		Example: help.Examples(`
 		    pc config set-api-key "api-key-value"
 		`),

--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -5,16 +5,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	indexHelp = help.Long(`
+		Work with Pinecone indexes.
+
+		An index is the highest-level organizational unit of vector data in Pinecone. 
+		You store vector data in an index, and perform queries and operations on the data stored.
+		There are two types of indexes: dense and sparse.
+		
+		See: https://docs.pinecone.io/guides/index-data/indexing-overview
+	`)
+)
+
 func NewIndexCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "Work with indexes",
-		Long: help.Long(`
-			An index is the highest-level organizational unit of 
-			vector data in Pinecone. It accepts and stores vectors, serves queries 
-			over the vectors it contains, and does other vector operations over 
-			its contents.
-		`),
+		Long:  indexHelp,
 		Example: help.Examples(`
 			pc index list
 			pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1

--- a/internal/pkg/cli/command/index/configure.go
+++ b/internal/pkg/cli/command/index/configure.go
@@ -29,7 +29,7 @@ func NewConfigureIndexCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "configure",
-		Short: "Configure an existing index with the specified configuration",
+		Short: "Configure an existing index",
 		Example: help.Examples(`
 			pc index configure --name "index-name" --deletion-protection "enabled"
 		`),

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -61,33 +61,37 @@ type createIndexOptions struct {
 	json bool
 }
 
+var (
+	createIndexHelp = help.LongF(`
+		Create a new index with the specified configuration.
+		
+		You can specify the measure of similarity, the dimension of vectors to be stored, and which cloud
+		provider you would like to deploy with. You can also control whether the index is 'sparse', or 'dense',
+		or any integrated embedding configuration you would like to use.
+
+		See: %s
+	`, docslinks.DocsIndexCreate)
+
+	createIndexExample = help.Examples(`
+		# create a serverless index
+		pc index create --name "my-index" --dimension 1536 --metric "cosine" --cloud "aws" --region "us-east-1"
+
+		# create a pod index
+		pc index create --name "my-index" --dimension 1536 --metric "cosine" --environment "us-east-1-aws" --pod-type "p1.x1" --shards 2 --replicas 2
+
+		# create an integrated index
+		pc index create --name "my-index" --dimension 1536 --metric "cosine" --cloud "aws" --region "us-east-1" --model "multilingual-e5-large" --field_map "text=chunk_text"
+	`)
+)
+
 func NewCreateIndexCmd() *cobra.Command {
 	options := createIndexOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new index with the specified configuration",
-		Long: help.LongF(`
-			The %s command creates a new index with the specified configuration. There are several different types of indexes
-			you can create depending on the configuration provided:
-
-				- Serverless (dense or sparse)
-				- Integrated 
-				- Pod
-
-			For detailed documentation, see:
-			%s
-			`, "pc index create", docslinks.DocsIndexCreate),
-		Example: help.Examples(`
-			# create a serverless index
-			pc index create --name "my-index" --dimension 1536 --metric "cosine" --cloud "aws" --region "us-east-1"
-
-			# create a pod index
-			pc index create --name "my-index" --dimension 1536 --metric "cosine" --environment "us-east-1-aws" --pod-type "p1.x1" --shards 2 --replicas 2
-
-			# create an integrated index
-			pc index create --name "my-index" --dimension 1536 --metric "cosine" --cloud "aws" --region "us-east-1" --model "multilingual-e5-large" --field_map "text=chunk_text"
-		`),
+		Use:     "create",
+		Short:   "Create a new index with the specified configuration",
+		Long:    createIndexHelp,
+		Example: createIndexExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			runCreateIndexCmd(options)
 		},

--- a/internal/pkg/cli/command/index/describe.go
+++ b/internal/pkg/cli/command/index/describe.go
@@ -24,7 +24,7 @@ func NewDescribeCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Get configuration and status information for an index by name",
+		Short: "Describe an index by name",
 		Example: help.Examples(`
 			pc index describe --name "index-name"
 		`),

--- a/internal/pkg/cli/command/index/list.go
+++ b/internal/pkg/cli/command/index/list.go
@@ -27,7 +27,7 @@ func NewListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "See the list of indexes in the targeted project",
+		Short: "List all of the indexes in the targeted project",
 		Example: help.Examples(`
 			pc index list
 		`),

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -9,10 +9,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	loginHelp = help.Long(`
+		Authenticate with Pinecone via user login in a web browser.
+
+		After logging in, a target organization and project context will be automatically set.
+		You can set a new target organization or project using pc target before accessing control
+		and data plane resources.
+	`)
+)
+
 func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to the Pinecone CLI through the browser using your Pinecone account",
+		Short: "Authenticate with Pinecone via user login in a web browser",
+		Long:  loginHelp,
 		Example: help.Examples(`
 			pc login
 		`),

--- a/internal/pkg/cli/command/logout/logout.go
+++ b/internal/pkg/cli/command/logout/logout.go
@@ -11,7 +11,7 @@ import (
 func NewLogoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Clear your authentication credentials, and delete all saved tokens and keys",
+		Short: "Clear your authentication credentials, and remove all locally stored API keys",
 		Example: help.Examples(`
 			pc logout
 		`),

--- a/internal/pkg/cli/command/organization/cmd.go
+++ b/internal/pkg/cli/command/organization/cmd.go
@@ -5,10 +5,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	organizationHelp = help.Long(`
+		Manage Pinecone organizations.
+
+		An organization is a collection of projects. Organizations allow one or more users to
+		control billing and project permissions for all of the projects belonging to the organization.
+
+		When authenticating with Pinecone through the CLI, organizations are intrinsically linked to 
+		user credentials. If you have authenticated using pc auth login, you will be able to target, list
+		and manage any organizations linked to that account. If you have authenticated using a service account,
+		or an explicit API key, you will be scoped to the organization associated with that account.
+
+		See: https://docs.pinecone.io/guides/organizations/understanding-organizations
+	`)
+)
+
 func NewOrganizationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "organization <command>",
 		Short:   "Manage Pinecone organizations",
+		Long:    organizationHelp,
 		GroupID: help.GROUP_ADMIN.ID,
 	}
 

--- a/internal/pkg/cli/command/organization/describe.go
+++ b/internal/pkg/cli/command/organization/describe.go
@@ -23,7 +23,7 @@ func NewDescribeOrganizationCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Describe an organization by ID or the target organization",
+		Short: "Describe an organization by ID, or the target organization",
 		Example: help.Examples(`
 			pc organization describe --id "organization-id"
 		`),

--- a/internal/pkg/cli/command/organization/list.go
+++ b/internal/pkg/cli/command/organization/list.go
@@ -25,7 +25,7 @@ func NewListOrganizationsCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all organizations available to the currently authenticated user",
+		Short: "List all organizations available to the authenticated user",
 		Example: help.Examples(`
 			pc organization list
 		`),

--- a/internal/pkg/cli/command/organization/update.go
+++ b/internal/pkg/cli/command/organization/update.go
@@ -26,7 +26,7 @@ func NewUpdateOrganizationCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update an existing organization by ID or the target organization with the specified configuration",
+		Short: "Update an existing organization by ID, or the target organization",
 		Example: help.Examples(`
 			pc organization update --id "organization-id" --name "new-name"
 		`),

--- a/internal/pkg/cli/command/project/cmd.go
+++ b/internal/pkg/cli/command/project/cmd.go
@@ -5,10 +5,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	projectHelp = help.Long(`
+		Manage Pinecone project. 
+
+		A Pinecone project belongs to an organization and contains a number of 
+		resources such as indexes, users, and API keys. Only a user who belongs 
+		to the project can access the resources in that project. Each project
+		also has at least one project owner.
+
+		See: https://docs.pinecone.io/guides/projects/understanding-projects
+	`)
+)
+
 func NewProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "project <command>",
 		Short:   "Manage Pinecone projects",
+		Long:    projectHelp,
 		GroupID: help.GROUP_ADMIN.ID,
 	}
 

--- a/internal/pkg/cli/command/project/create.go
+++ b/internal/pkg/cli/command/project/create.go
@@ -24,12 +24,24 @@ type CreateProjectCmdOptions struct {
 	json                    bool
 }
 
+var (
+	createHelp = help.Long(`
+		Create a project for the target organization determined by user credentials.
+		
+		If you'd like to set the created project as the target project within the CLI,
+		you can provide the --target flag.
+
+		See: https://docs.pinecone.io/guides/projects/manage-projects
+	`)
+)
+
 func NewCreateProjectCmd() *cobra.Command {
 	options := CreateProjectCmdOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a project for the target organization determined by user credentials",
+		Long:    createHelp,
 		GroupID: help.GROUP_PROJECTS.ID,
 		Example: help.Examples(`
 			pc project create --name "demo-project" --max-pods 10 --force-encryption

--- a/internal/pkg/cli/command/project/delete.go
+++ b/internal/pkg/cli/command/project/delete.go
@@ -28,7 +28,7 @@ func NewDeleteProjectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a specific project by ID or the target project",
+		Short: "Delete a specific project by ID, or the target project",
 		Example: help.Examples(`
 			# Delete the target project
 			pc project delete

--- a/internal/pkg/cli/command/project/describe.go
+++ b/internal/pkg/cli/command/project/describe.go
@@ -25,7 +25,7 @@ func NewDescribeProjectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "describe",
-		Short:   "Describe a specific project by ID or the target project",
+		Short:   "Describe a specific project by ID, or the target project",
 		GroupID: help.GROUP_PROJECTS.ID,
 		Example: help.Examples(`
 			pc project describe --id "project-id"

--- a/internal/pkg/cli/command/project/list.go
+++ b/internal/pkg/cli/command/project/list.go
@@ -27,7 +27,7 @@ func NewListProjectsCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "list all projects in the organization available to the authenticated user",
+		Short:   "List all projects in the target organization determined by user credentials",
 		GroupID: help.GROUP_PROJECTS.ID,
 		Example: help.Examples(`
 			pc project list

--- a/internal/pkg/cli/command/project/update.go
+++ b/internal/pkg/cli/command/project/update.go
@@ -30,7 +30,7 @@ func NewUpdateProjectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update an existing project by ID or the target project with the specified configuration",
+		Short: "Update an existing project by ID, or the target project",
 		Example: help.Examples(`
 			pc project update --id "project-id" --name "new-name" --max-pods 5
 		`),

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -52,7 +52,7 @@ func init() {
 		Long: help.Long(`
 			pc is a CLI tool for managing your Pinecone resources
 
-			Get started by logging in with $ pc login
+			Get started by logging in with pc login
 		`),
 	}
 

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/project"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/target"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/version"
+	"github.com/pinecone-io/cli/internal/pkg/cli/command/whoami"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	"github.com/pinecone-io/cli/internal/pkg/utils/pcio"
 	"github.com/spf13/cobra"
@@ -36,11 +37,24 @@ func GetRootCmd() *cobra.Command {
 	return rootCmd
 }
 
+var (
+	rootHelp = help.Long(`
+		Work seamlessly with Pinecone from the command line.
+
+		pc is a CLI tool for managing Pinecone infrastructure (projects, organizations,
+		API keys, indexes) directly from your terminal.
+		
+		Get started by logging in with pc login
+
+		See: https://docs.pinecone.io/reference/tools/cli-overview
+	`)
+)
+
 func init() {
 	globalOptions := GlobalOptions{}
 	rootCmd = &cobra.Command{
 		Use:   "pc",
-		Short: "Work seamlessly with Pinecone from the command line.",
+		Short: "Work seamlessly with Pinecone from the command line",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			pcio.SetQuiet(globalOptions.quiet)
 		},
@@ -49,11 +63,7 @@ func init() {
 			pc target
 			pc index create --help
 		`),
-		Long: help.Long(`
-			pc is a CLI tool for managing your Pinecone resources
-
-			Get started by logging in with pc login
-		`),
+		Long: rootHelp,
 	}
 
 	rootCmd.SetHelpTemplate(help.HelpTemplate)
@@ -65,7 +75,7 @@ func init() {
 	rootCmd.AddCommand(login.NewLoginCmd())
 	rootCmd.AddCommand(logout.NewLogoutCmd())
 	rootCmd.AddCommand(target.NewTargetCmd())
-	rootCmd.AddCommand(login.NewWhoAmICmd())
+	rootCmd.AddCommand(whoami.NewWhoAmICmd())
 
 	// Admin management group
 	rootCmd.AddGroup(help.GROUP_ADMIN)

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -43,8 +43,8 @@ func NewTargetCmd() *cobra.Command {
 			When using the CLI interactively (i.e. via the oauth2 authentication flow) you
 			should use this command to set the current project context for the CLI.
 
-			For automation use cases relying on API Keys for authentication, there's no need
-			to specify a project context as the API Key is already associated with a specific
+			For automation use cases relying on API keys for authentication, there's no need
+			to specify a project context as the API key is already associated with a specific
 			project in the backend.
 		`),
 		Example: help.Examples(`

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -32,31 +32,38 @@ type TargetCmdOptions struct {
 	show    bool
 }
 
+var (
+	targetHelp = help.Long(`
+		Set the target organization and project context for the CLI.
+
+		Operations for resources within the control and data plane take place in the context of a specific project.
+		After authenticating through the CLI with user login or service account credentials, you can use
+		this command to set the target organization or project context for control and data plane operations.
+
+		When using a global API key for authentication, there's no need to specify a project context as the API 
+		key is already associated with a specific organization and project.
+	`)
+
+	targetExample = help.Examples(`
+		# Interactively target from available organizations and projects
+		pc target
+
+		# Target an organization and project by name
+		pc target --org "organization-name" -project "project-name"
+
+		# Target a project by name
+		pc target --project "project-name"
+	`)
+)
+
 func NewTargetCmd() *cobra.Command {
 	options := TargetCmdOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "target <flags>",
-		Short: "Set context for the CLI",
-		Long: help.Long(`
-			Many API calls take place in the context of a specific project.
-			When using the CLI interactively (i.e. via the oauth2 authentication flow) you
-			should use this command to set the current project context for the CLI.
-
-			For automation use cases relying on API keys for authentication, there's no need
-			to specify a project context as the API key is already associated with a specific
-			project in the backend.
-		`),
-		Example: help.Examples(`
-			# Interactively target from available organizations and projects
-			pc target
-
-			# Target an organization and project by name
-			pc target --org "organization-name" -project "project-name"
-
-			# Target a project by name
-			pc target --project "project-name"
-		`),
+		Use:     "target <flags>",
+		Short:   "Set the target organization and project context for the CLI",
+		Long:    targetHelp,
+		Example: targetExample,
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Debug().

--- a/internal/pkg/cli/command/whoami/whoami.go
+++ b/internal/pkg/cli/command/whoami/whoami.go
@@ -1,4 +1,4 @@
-package login
+package whoami
 
 import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
@@ -14,7 +14,7 @@ import (
 func NewWhoAmICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
-		Short: "See the current logged in user",
+		Short: "See the currently logged in user",
 		Example: help.Examples(`
 			pc whoami
 		`),


### PR DESCRIPTION
## Problem
@bradumbaugh had a good callout on a previous PR around some of our commands, especially admin commands, missing more verbose help text. 

Areas currently lacking:
- `api-key`
- `project`
- `organization`
- `auth`
  - `login/logout`
  - `configure`
  - `local-keys`
- `target` 

## Solution
I've gone through and cleaned up all of our help-text definitions to be somewhat consistent across commands. I've also added in more verbose help text for the above commands, and tweaked some of the verbiage in others. These strings show up both for `--help`, and in man pages.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
No functional changes, documentation changes can be seen by running with `--help` or checking man pages.