### PR TITLE
Daemonize `login` OAuth listener

### DIFF
--- a/internal/pkg/cli/command/auth/cmd.go
+++ b/internal/pkg/cli/command/auth/cmd.go
@@ -42,6 +42,7 @@ func NewAuthCmd() *cobra.Command {
 	cmd.AddCommand(NewConfigureCmd())
 	cmd.AddCommand(NewClearCmd())
 	cmd.AddCommand(NewLocalKeysCmd())
+	cmd.AddCommand(NewDaemonCmd())
 
 	return cmd
 }

--- a/internal/pkg/cli/command/auth/daemon.go
+++ b/internal/pkg/cli/command/auth/daemon.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"github.com/pinecone-io/cli/internal/pkg/utils/login"
+	"github.com/spf13/cobra"
+)
+
+// NewDaemonCmd returns the hidden internal command spawned by `pc login --json`
+// to run the OAuth callback server in the background.
+func NewDaemonCmd() *cobra.Command {
+	var sessionId string
+
+	cmd := &cobra.Command{
+		Use:    "_daemon",
+		Hidden: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			login.RunDaemon(sessionId)
+		},
+	}
+
+	cmd.Flags().StringVar(&sessionId, "session-id", "", "session ID for the pending auth flow")
+	_ = cmd.MarkFlagRequired("session-id")
+
+	return cmd
+}

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -158,7 +158,7 @@ func NewTargetCmd() *cobra.Command {
 					// If the org chosen differs from the current orgId in the token, we need to login again
 					if currentTokenOrgId != "" && currentTokenOrgId != targetOrg.Id {
 						oauth.Logout()
-						err = login.GetAndSetAccessToken(ctx, &targetOrg.Id, login.Options{})
+						err = login.GetAndSetAccessToken(ctx, &targetOrg.Id, login.Options{Json: options.json})
 						if err != nil {
 							msg.FailJSON(options.json, "Failed to get access token: %s", err)
 							exit.Error(err, "Error getting access token")
@@ -204,7 +204,7 @@ func NewTargetCmd() *cobra.Command {
 				// If the org chosen differs from the current orgId in the token, we need to login again
 				if currentTokenOrgId != org.Id {
 					oauth.Logout()
-					err = login.GetAndSetAccessToken(ctx, &org.Id, login.Options{})
+					err = login.GetAndSetAccessToken(ctx, &org.Id, login.Options{Json: options.json})
 					if err != nil {
 						msg.FailJSON(options.json, "Failed to get access token: %s", err)
 						exit.Error(err, "Error getting access token")

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -158,7 +158,7 @@ func NewTargetCmd() *cobra.Command {
 					// If the org chosen differs from the current orgId in the token, we need to login again
 					if currentTokenOrgId != "" && currentTokenOrgId != targetOrg.Id {
 						oauth.Logout()
-						err = login.GetAndSetAccessToken(ctx, &targetOrg.Id, login.Options{Json: options.json})
+						err = login.GetAndSetAccessToken(ctx, &targetOrg.Id, login.Options{Json: options.json, Wait: true})
 						if err != nil {
 							msg.FailJSON(options.json, "Failed to get access token: %s", err)
 							exit.Error(err, "Error getting access token")
@@ -204,7 +204,7 @@ func NewTargetCmd() *cobra.Command {
 				// If the org chosen differs from the current orgId in the token, we need to login again
 				if currentTokenOrgId != org.Id {
 					oauth.Logout()
-					err = login.GetAndSetAccessToken(ctx, &org.Id, login.Options{Json: options.json})
+					err = login.GetAndSetAccessToken(ctx, &org.Id, login.Options{Json: options.json, Wait: true})
 					if err != nil {
 						msg.FailJSON(options.json, "Failed to get access token: %s", err)
 						exit.Error(err, "Error getting access token")

--- a/internal/pkg/utils/login/daemon.go
+++ b/internal/pkg/utils/login/daemon.go
@@ -48,6 +48,10 @@ func RunDaemon(sessionId string) {
 		writeDaemonError(sessionId, fmt.Sprintf("error exchanging auth code: %s", err))
 		return
 	}
+	if token == nil {
+		writeDaemonError(sessionId, "error exchanging auth code: no token returned")
+		return
+	}
 
 	claims, err := oauth.ParseClaimsUnverified(token)
 	if err != nil {

--- a/internal/pkg/utils/login/daemon.go
+++ b/internal/pkg/utils/login/daemon.go
@@ -1,0 +1,85 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
+	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
+	"github.com/pinecone-io/cli/internal/pkg/utils/log"
+	"github.com/pinecone-io/cli/internal/pkg/utils/oauth"
+)
+
+// RunDaemon is called by the hidden `pc auth _daemon` subcommand. It reads the
+// session state written by the parent, runs the OAuth callback server, exchanges
+// the auth code for a token, stores the token, and writes a result file.
+// It must not write to stdout/stderr since it runs detached from any terminal.
+func RunDaemon(sessionId string) {
+	ctx, cancel := context.WithTimeout(context.Background(), sessionMaxAge)
+	defer cancel()
+
+	sess, err := ReadSessionState(sessionId)
+	if err != nil {
+		writeDaemonError(sessionId, fmt.Sprintf("error reading session state: %s", err))
+		return
+	}
+
+	codeCh := make(chan string, 1)
+	go func() {
+		code, err := ServeAuthCodeListener(ctx, sess.CSRFState)
+		if err != nil {
+			log.Error().Err(err).Str("session_id", sessionId).Msg("daemon: error waiting for authorization")
+			codeCh <- ""
+			return
+		}
+		codeCh <- code
+	}()
+
+	code := <-codeCh
+	if code == "" {
+		writeDaemonError(sessionId, "authentication timed out or failed: no auth code received")
+		return
+	}
+
+	a := oauth.Auth{}
+	token, err := a.ExchangeAuthCode(ctx, sess.PKCEVerifier, code)
+	if err != nil {
+		writeDaemonError(sessionId, fmt.Sprintf("error exchanging auth code: %s", err))
+		return
+	}
+
+	claims, err := oauth.ParseClaimsUnverified(token)
+	if err != nil {
+		writeDaemonError(sessionId, fmt.Sprintf("error parsing token claims: %s", err))
+		return
+	}
+
+	secrets.SetOAuth2Token(*token)
+	secrets.ClientId.Set("")
+	secrets.ClientSecret.Set("")
+
+	authContext := state.AuthUserToken
+	if state.AuthedUser.Get().AuthContext == state.AuthDefaultAPIKey {
+		authContext = state.AuthDefaultAPIKey
+	}
+	state.AuthedUser.Set(state.TargetUser{
+		AuthContext: authContext,
+		Email:       claims.Email,
+	})
+
+	_ = WriteSessionResult(SessionResult{
+		SessionId:   sessionId,
+		Status:      "success",
+		CompletedAt: time.Now(),
+	})
+}
+
+func writeDaemonError(sessionId, errMsg string) {
+	_ = WriteSessionResult(SessionResult{
+		SessionId:   sessionId,
+		Status:      "error",
+		Error:       errMsg,
+		CompletedAt: time.Now(),
+	})
+}

--- a/internal/pkg/utils/login/daemon.go
+++ b/internal/pkg/utils/login/daemon.go
@@ -3,6 +3,7 @@ package login
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
@@ -42,8 +43,14 @@ func RunDaemon(sessionId string) {
 		return
 	}
 
+	pkceVerifier := os.Getenv("PINECONE_PKCE_VERIFIER")
+	if pkceVerifier == "" {
+		writeDaemonError(sessionId, "PKCE verifier not provided to daemon")
+		return
+	}
+
 	a := oauth.Auth{}
-	token, err := a.ExchangeAuthCode(ctx, sess.PKCEVerifier, code)
+	token, err := a.ExchangeAuthCode(ctx, pkceVerifier, code)
 	if err != nil {
 		writeDaemonError(sessionId, fmt.Sprintf("error exchanging auth code: %s", err))
 		return

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -331,17 +331,23 @@ func printPendingJSON(authURL, sessionId string) {
 // getAndSetAccessTokenInteractive is the original interactive path: inline callback server,
 // optional [Enter]-to-open-browser prompt when stdin is a TTY.
 func getAndSetAccessTokenInteractive(ctx context.Context, orgId *string) error {
-	// If a daemon from a prior JSON-mode login is still running, it holds the
-	// callback port. Attempting to bind the same port would fail with a confusing
-	// "address already in use" error. Detect this upfront and tell the user.
-	sess, _, err := findResumableSession()
+	// If a daemon from a prior JSON-mode login exists, check whether it has
+	// already finished before deciding whether to block interactive login.
+	sess, result, err := findResumableSession()
 	if err != nil {
 		return fmt.Errorf("error checking for existing auth session: %w", err)
 	}
 	if sess != nil {
-		fmt.Fprintf(os.Stderr, "An authentication flow is already in progress. Visit the URL below to complete it:\n\n  %s\n\n", sess.AuthURL)
-		return fmt.Errorf("authentication already in progress (started at %s) — complete the existing flow or wait for it to expire",
-			sess.CreatedAt.Format(time.RFC3339))
+		if result != nil {
+			// Daemon finished (success or error) and has released the port.
+			// Clean up the stale session and proceed with interactive login.
+			CleanupSession(sess.SessionId)
+		} else {
+			// Daemon is still running and holds the callback port.
+			fmt.Fprintf(os.Stderr, "An authentication flow is already in progress. Visit the URL below to complete it:\n\n  %s\n\n", sess.AuthURL)
+			return fmt.Errorf("authentication already in progress (started at %s) — complete the existing flow or wait for it to expire",
+				sess.CreatedAt.Format(time.RFC3339))
+		}
 	}
 
 	a := oauth.Auth{}

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -253,8 +253,9 @@ func resumeSession(sess *SessionState, result *SessionResult) error {
 		defer cancel()
 		return RunPostAuthSetup(setupCtx)
 	}
-	// Still pending — re-surface the URL and keep polling.
-	printPendingJSON(sess.AuthURL, sess.SessionId)
+	// Still pending — poll until the daemon completes and emit authenticated JSON.
+	// Don't re-emit pending here: this call will block until done and emit exactly
+	// one JSON object (authenticated), keeping stdout to a single JSON value per invocation.
 	return pollForResult(sess.SessionId, sess.CreatedAt)
 }
 

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -328,6 +328,19 @@ func printPendingJSON(authURL, sessionId string) {
 // getAndSetAccessTokenInteractive is the original interactive path: inline callback server,
 // optional [Enter]-to-open-browser prompt when stdin is a TTY.
 func getAndSetAccessTokenInteractive(ctx context.Context, orgId *string) error {
+	// If a daemon from a prior JSON-mode login is still running, it holds the
+	// callback port. Attempting to bind the same port would fail with a confusing
+	// "address already in use" error. Detect this upfront and tell the user.
+	sess, _, err := findResumableSession()
+	if err != nil {
+		return fmt.Errorf("error checking for existing auth session: %w", err)
+	}
+	if sess != nil {
+		fmt.Fprintf(os.Stderr, "An authentication flow is already in progress. Visit the URL below to complete it:\n\n  %s\n\n", sess.AuthURL)
+		return fmt.Errorf("authentication already in progress (started at %s) — complete the existing flow or wait for it to expire",
+			sess.CreatedAt.Format(time.RFC3339))
+	}
+
 	a := oauth.Auth{}
 	csrfState := randomCSRFState()
 

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -11,6 +11,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"os/exec"
 	"time"
 
 	"golang.org/x/term"
@@ -43,10 +44,8 @@ type Options struct {
 
 func Run(ctx context.Context, opts Options) {
 	// Resolve output format once at the top level: explicit --json flag or auto-detected non-TTY stdout.
-	// Normalizing opts.Json here means GetAndSetAccessToken and other helpers use opts.Json directly.
 	opts.Json = opts.Json || !term.IsTerminal(int(os.Stdout.Fd()))
 
-	// Check if the user is currently logged in
 	token, err := oauth.Token(ctx)
 
 	var te *oauth.TokenError
@@ -76,14 +75,18 @@ func Run(ctx context.Context, opts Options) {
 		return
 	}
 
-	// Initiate login flow
 	err = GetAndSetAccessToken(ctx, nil, opts)
 	if err != nil {
 		msg.FailMsg("Error acquiring access token while logging in: %s", err)
 		exit.Error(err, "Error acquiring access token while logging in")
 	}
 
-	// Parse token claims to get orgId
+	if opts.Json {
+		// JSON mode: GetAndSetAccessToken handled all output (pending → polling → authenticated).
+		return
+	}
+
+	// Non-JSON: complete post-auth setup with human-readable output.
 	token, err = oauth.Token(ctx)
 	if err != nil {
 		msg.FailMsg("Error retrieving oauth token: %s", err)
@@ -94,18 +97,11 @@ func Run(ctx context.Context, opts Options) {
 		msg.FailMsg("An auth token was fetched but an error occurred while parsing the token's claims: %s", err)
 		exit.Error(err, "Error parsing claims from access token")
 	}
-	if !opts.Json {
-		msg.Blank()
-		msg.SuccessMsg("Logged in as %s. Defaulted to organization ID: %s", style.Emphasis(claims.Email), style.Emphasis(claims.OrgId))
-	}
+	msg.Blank()
+	msg.SuccessMsg("Logged in as %s. Defaulted to organization ID: %s", style.Emphasis(claims.Email), style.Emphasis(claims.OrgId))
 
 	ac := sdk.NewPineconeAdminClient(ctx)
-	if err != nil {
-		msg.FailMsg("Error creating Pinecone admin client: %s", err)
-		exit.Error(err, "Error creating Pinecone admin client")
-	}
 
-	// Fetch the user's organizations and projects for the default org associated with the JWT token (if it exists)
 	orgs, err := ac.Organization.List(ctx)
 	if err != nil {
 		msg.FailMsg("Error fetching organizations: %s", err)
@@ -118,7 +114,6 @@ func Run(ctx context.Context, opts Options) {
 		exit.Error(err, "Error fetching projects")
 	}
 
-	// target organization is whatever the JWT token's orgId is - defaults on first login currently
 	var targetOrg *pinecone.Organization
 	for _, org := range orgs {
 		if org.Id == claims.OrgId {
@@ -132,55 +127,57 @@ func Run(ctx context.Context, opts Options) {
 		Id:   targetOrg.Id,
 	})
 
-	if opts.Json {
-		projectId := ""
-		if len(projects) > 0 {
+	msg.InfoMsg("Target org set to %s.", style.Emphasis(targetOrg.Name))
+
+	if projects != nil {
+		if len(projects) == 0 {
+			msg.InfoMsg("No projects found for organization %s.", style.Emphasis(targetOrg.Name))
+			msg.InfoMsg("Please create a project for this organization to work with project resources.")
+		} else {
 			targetProj := projects[0]
 			state.TargetProj.Set(state.TargetProject{
 				Name: targetProj.Name,
 				Id:   targetProj.Id,
 			})
-			projectId = targetProj.Id
+			msg.InfoMsg("Target project set %s.", style.Emphasis(targetProj.Name))
 		}
-		fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
-			Status    string `json:"status"`
-			Email     string `json:"email"`
-			OrgId     string `json:"org_id"`
-			ProjectId string `json:"project_id"`
-		}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, ProjectId: projectId}))
-	} else {
-		msg.InfoMsg("Target org set to %s.", style.Emphasis(targetOrg.Name))
-
-		if projects != nil {
-			if len(projects) == 0 {
-				msg.InfoMsg("No projects found for organization %s.", style.Emphasis(targetOrg.Name))
-				msg.InfoMsg("Please create a project for this organization to work with project resources.")
-			} else {
-				targetProj := projects[0]
-				state.TargetProj.Set(state.TargetProject{
-					Name: targetProj.Name,
-					Id:   targetProj.Id,
-				})
-
-				msg.InfoMsg("Target project set %s.", style.Emphasis(targetProj.Name))
-			}
-		}
-
-		msg.Blank()
-		msg.HintMsg("Run %s to change the target context.", style.Code("pc target"))
-		msg.HintMsg("Now try %s to learn about index operations.", style.Code("pc index -h"))
 	}
+
+	msg.Blank()
+	msg.HintMsg("Run %s to change the target context.", style.Code("pc target"))
+	msg.HintMsg("Now try %s to learn about index operations.", style.Code("pc index -h"))
 }
 
-// Takes an optional orgId, and attempts to acquire an access token scoped to the orgId if provided.
-// If a token is successfully acquired it's set in the secrets store, and the user is considered logged in with state.AuthUserToken.
+// GetAndSetAccessToken acquires an OAuth token via the PKCE browser flow and stores it.
+//
+// Non-JSON mode: runs the callback server inline (blocking), prompts for [Enter] to open
+// the browser when stdin is an interactive TTY.
+//
+// JSON mode: spawns a background daemon that owns the local callback server, prints
+// {"status":"pending","url":"..."} immediately so agents can extract the URL from partial
+// output, then polls the daemon's result file. When the daemon completes it prints
+// {"status":"authenticated",...} and returns. If this process is killed before the daemon
+// finishes (e.g. an agent timeout), the daemon keeps running; the next call to this
+// function will detect the pending session and resume polling rather than starting a new flow.
 func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) error {
-	a := oauth.Auth{}
+	if opts.Json {
+		return getAndSetAccessTokenJSON(ctx, orgId)
+	}
+	return getAndSetAccessTokenInteractive(ctx, orgId)
+}
 
-	// CSRF state
+// getAndSetAccessTokenJSON is the agentic path: daemon-backed, non-blocking on stdin.
+func getAndSetAccessTokenJSON(ctx context.Context, orgId *string) error {
+	// Resume a pending session if one exists (e.g. this process was killed mid-poll).
+	sess, result, err := findResumableSession()
+	if err == nil && sess != nil {
+		return resumeSession(ctx, sess, result)
+	}
+
+	// Start a new flow.
+	a := oauth.Auth{}
 	csrfState := randomCSRFState()
 
-	// PKCE verifier and challenge
 	verifier, challenge, err := a.CreateNewVerifierAndChallenge()
 	if err != nil {
 		return fmt.Errorf("error creating new auth verifier and challenge: %w", err)
@@ -191,9 +188,111 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 		return fmt.Errorf("error getting auth URL: %w", err)
 	}
 
-	// Spin up a local server in a goroutine to handle receiving the authorization code from auth0
+	sessionId := newSessionId()
+	sess = &SessionState{
+		SessionId:    sessionId,
+		PKCEVerifier: verifier,
+		CSRFState:    csrfState,
+		AuthURL:      authURL,
+		OrgId:        orgId,
+		CreatedAt:    time.Now(),
+	}
+	if err := writeSessionState(*sess); err != nil {
+		return fmt.Errorf("error writing session state: %w", err)
+	}
+	if err := spawnDaemon(sessionId); err != nil {
+		CleanupSession(sessionId)
+		return fmt.Errorf("error spawning auth daemon: %w", err)
+	}
+
+	// Print the pending JSON and exit immediately. The daemon owns the callback
+	// server and will write a result file when auth completes. The next invocation
+	// of this command will detect the pending session and poll for the result.
+	printPendingJSON(authURL, sessionId)
+	return nil
+}
+
+// resumeSession handles a session that was already started (e.g. after a process restart).
+// If the daemon already finished, it handles the result immediately. Otherwise it re-prints
+// the pending URL and continues polling.
+func resumeSession(ctx context.Context, sess *SessionState, result *SessionResult) error {
+	if result != nil {
+		// Daemon already completed while we were away.
+		defer CleanupSession(sess.SessionId)
+		if result.Status == "error" {
+			return fmt.Errorf("authentication failed: %s", result.Error)
+		}
+		_ = secrets.SecretsViper.ReadInConfig()
+		return RunPostAuthSetup(ctx)
+	}
+	// Still pending — re-surface the URL and keep polling.
+	printPendingJSON(sess.AuthURL, sess.SessionId)
+	return pollForResult(ctx, sess.SessionId)
+}
+
+// pollForResult polls the daemon's result file until auth completes or the session expires.
+// On success it runs post-auth setup and emits the final authenticated JSON.
+// On timeout it returns without cleaning up so the daemon can still complete and be
+// resumed on the next invocation.
+func pollForResult(ctx context.Context, sessionId string) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	deadline := time.NewTimer(sessionMaxAge)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			// Don't clean up — daemon may still complete; next call will resume.
+			return errors.New("timed out waiting for authentication")
+		case <-ticker.C:
+			result, err := readSessionResult(sessionId)
+			if err != nil {
+				return fmt.Errorf("error reading session result: %w", err)
+			}
+			if result == nil {
+				continue // daemon not done yet
+			}
+			defer CleanupSession(sessionId)
+			if result.Status == "error" {
+				return fmt.Errorf("authentication failed: %s", result.Error)
+			}
+			// The daemon wrote the token to secrets.yaml from a separate process.
+			// Reload from disk so this process's Viper cache reflects it.
+			_ = secrets.SecretsViper.ReadInConfig()
+			return RunPostAuthSetup(ctx)
+		}
+	}
+}
+
+func printPendingJSON(authURL, sessionId string) {
+	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
+		Status    string `json:"status"`
+		URL       string `json:"url"`
+		SessionId string `json:"session_id"`
+	}{Status: "pending", URL: authURL, SessionId: sessionId}))
+}
+
+// getAndSetAccessTokenInteractive is the original interactive path: inline callback server,
+// optional [Enter]-to-open-browser prompt when stdin is a TTY.
+func getAndSetAccessTokenInteractive(ctx context.Context, orgId *string) error {
+	a := oauth.Auth{}
+	csrfState := randomCSRFState()
+
+	verifier, challenge, err := a.CreateNewVerifierAndChallenge()
+	if err != nil {
+		return fmt.Errorf("error creating new auth verifier and challenge: %w", err)
+	}
+
+	authURL, err := a.GetAuthURL(ctx, csrfState, challenge, orgId)
+	if err != nil {
+		return fmt.Errorf("error getting auth URL: %w", err)
+	}
+
 	codeCh := make(chan string, 1)
-	serverCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	serverCtx, cancel := context.WithTimeout(ctx, sessionMaxAge)
 	defer cancel()
 
 	go func() {
@@ -206,28 +305,14 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 		codeCh <- code
 	}()
 
-	if opts.Json {
-		fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
-			Status string `json:"status"`
-			URL    string `json:"url"`
-		}{Status: "pending", URL: authURL}))
-	} else {
-		fmt.Fprintf(os.Stderr, "Visit %s to authorize the CLI.\n", style.Underline(authURL))
-	}
+	fmt.Fprintf(os.Stderr, "Visit %s to authorize the CLI.\n", style.Underline(authURL))
 
-	// Prompt for [Enter] and spawn stdin reader whenever stdin is an interactive TTY,
-	// regardless of output format. JSON mode only affects what goes to stdout — a user
-	// running --json in a terminal is still at a keyboard and benefits from browser-open.
-	// The prompt goes to stderr so it never corrupts the stdout JSON stream.
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		msg.Blank()
 		fmt.Fprintf(os.Stderr, "Press %s to open the browser, or manually paste the URL above.\n", style.Code("[Enter]"))
 
 		go func(ctx context.Context) {
-			// inner channel to signal that [Enter] was pressed
 			inputCh := make(chan struct{}, 1)
-
-			// spawn inner goroutine to read stdin (blocking)
 			go func() {
 				_, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
 				if err != nil {
@@ -236,8 +321,6 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 				}
 				close(inputCh)
 			}()
-
-			// wait for [Enter], auth code, or timeout
 			select {
 			case <-ctx.Done():
 				return
@@ -245,14 +328,12 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 				if err := browser.OpenBrowser(authURL); err != nil {
 					log.Error().Err(err).Msg("error opening browser")
 				}
-			case <-time.After(5 * time.Minute):
-				// extra precaution to prevent hanging indefinitely on stdin
+			case <-time.After(sessionMaxAge):
 				return
 			}
 		}(serverCtx)
 	}
 
-	// Wait for auth code and exchange for access token
 	code := <-codeCh
 	if code == "" {
 		return errors.New("error authenticating CLI and retrieving oauth2 access token")
@@ -270,17 +351,11 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 	}
 
 	if token != nil {
-		// Store the token
 		secrets.SetOAuth2Token(*token)
-
-		// Clear any existing client_id and client_secret values
 		secrets.ClientId.Set("")
 		secrets.ClientSecret.Set("")
 
-		// Update target credentials context
 		authContext := state.AuthUserToken
-
-		// If there's a default API key set, we want to keep that as the current auth context
 		if state.AuthedUser.Get().AuthContext == state.AuthDefaultAPIKey {
 			authContext = state.AuthDefaultAPIKey
 		}
@@ -293,11 +368,83 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 	return nil
 }
 
+// RunPostAuthSetup fetches the user's org/project context, sets target defaults,
+// and emits the final {"status":"authenticated",...} JSON.
+func RunPostAuthSetup(ctx context.Context) error {
+	token, err := oauth.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("error retrieving oauth token: %w", err)
+	}
+	claims, err := oauth.ParseClaimsUnverified(token)
+	if err != nil {
+		return fmt.Errorf("error parsing token claims: %w", err)
+	}
+
+	ac := sdk.NewPineconeAdminClient(ctx)
+
+	orgs, err := ac.Organization.List(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching organizations: %w", err)
+	}
+	projects, err := ac.Project.List(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching projects: %w", err)
+	}
+
+	var targetOrg *pinecone.Organization
+	for _, org := range orgs {
+		if org.Id == claims.OrgId {
+			targetOrg = org
+			break
+		}
+	}
+	if targetOrg == nil {
+		return fmt.Errorf("target organization %s not found", claims.OrgId)
+	}
+
+	state.TargetOrg.Set(state.TargetOrganization{
+		Name: targetOrg.Name,
+		Id:   targetOrg.Id,
+	})
+
+	projectId := ""
+	if len(projects) > 0 {
+		targetProj := projects[0]
+		state.TargetProj.Set(state.TargetProject{
+			Name: targetProj.Name,
+			Id:   targetProj.Id,
+		})
+		projectId = targetProj.Id
+	}
+
+	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
+		Status    string `json:"status"`
+		Email     string `json:"email"`
+		OrgId     string `json:"org_id"`
+		ProjectId string `json:"project_id"`
+	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, ProjectId: projectId}))
+
+	return nil
+}
+
+// spawnDaemon starts a detached `pc auth _daemon --session-id <id>` process.
+func spawnDaemon(sessionId string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("error finding executable path: %w", err)
+	}
+	cmd := exec.Command(exe, "auth", "_daemon", "--session-id", sessionId)
+	detachProcess(cmd)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Start()
+}
+
 func ServeAuthCodeListener(ctx context.Context, csrfState string) (string, error) {
 	codeCh := make(chan string)
 	errCh := make(chan error)
 
-	// start server to receive the auth code
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth-callback", func(w http.ResponseWriter, r *http.Request) {
 		code := r.URL.Query().Get("code")
@@ -308,7 +455,6 @@ func ServeAuthCodeListener(ctx context.Context, csrfState string) (string, error
 			return
 		}
 
-		// Code is empty, there was an error authenticating, return error HTML
 		templateData := map[string]template.HTML{"LogoSVG": template.HTML(logoSVG)}
 		if code == "" {
 			if err := renderHTML(w, errorHTML, templateData); err != nil {
@@ -325,7 +471,6 @@ func ServeAuthCodeListener(ctx context.Context, csrfState string) (string, error
 		codeCh <- code
 	})
 
-	// Start server and listen for auth code response
 	serve := &http.Server{
 		Addr:    "127.0.0.1:59049",
 		Handler: mux,

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -40,6 +40,12 @@ var logoSVG string
 
 type Options struct {
 	Json bool
+	// Wait makes the daemon path block until the token is acquired and stored,
+	// rather than returning immediately after printing "pending". Use this when
+	// the caller needs a valid token on return (e.g. pc target re-auth).
+	// RunPostAuthSetup is not called in Wait mode; the caller is responsible
+	// for any post-auth state setup and output.
+	Wait bool
 }
 
 func Run(ctx context.Context, opts Options) {
@@ -56,7 +62,7 @@ func Run(ctx context.Context, opts Options) {
 			exit.Error(err, "Error checking for existing auth session")
 		}
 		if sess != nil {
-			if err := getAndSetAccessTokenJSON(ctx, nil, sess, result); err != nil {
+			if err := getAndSetAccessTokenJSON(ctx, nil, false, sess, result); err != nil {
 				msg.FailMsg("Error acquiring access token while logging in: %s", err)
 				exit.Error(err, "Error acquiring access token while logging in")
 			}
@@ -182,7 +188,7 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 	// a terminal (agentic context), always use the JSON/daemon path.
 	opts.Json = opts.Json || !term.IsTerminal(int(os.Stdout.Fd()))
 	if opts.Json {
-		return getAndSetAccessTokenJSON(ctx, orgId, nil, nil)
+		return getAndSetAccessTokenJSON(ctx, orgId, opts.Wait, nil, nil)
 	}
 	return getAndSetAccessTokenInteractive(ctx, orgId)
 }
@@ -190,7 +196,14 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 // getAndSetAccessTokenJSON is the agentic path: daemon-backed, non-blocking on stdin.
 // sess and result may be pre-fetched by the caller to avoid a redundant directory scan;
 // if nil, findResumableSession is called here.
-func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionState, result *SessionResult) error {
+//
+// When wait is false (default for pc login): spawns daemon, prints pending JSON, and
+// returns immediately. The caller is expected to call again to poll for the result.
+//
+// When wait is true (for callers like pc target that need a token on return): spawns
+// daemon, blocks until auth completes, and returns with the token stored. RunPostAuthSetup
+// is not called; the caller owns post-auth state and output.
+func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, wait bool, sess *SessionState, result *SessionResult) error {
 	if sess == nil {
 		// No pre-fetched session — look one up now.
 		var err error
@@ -200,7 +213,20 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionS
 		}
 	}
 	if sess != nil {
-		return resumeSession(sess, result)
+		// If the caller is requesting a specific org that doesn't match the pending
+		// session's org, the existing session cannot be used.
+		if orgId != nil && sess.OrgId != nil && *orgId != *sess.OrgId {
+			if result != nil {
+				// Daemon has finished and released the port — clean up and start fresh.
+				CleanupSession(sess.SessionId)
+				// Fall through to start a new flow.
+			} else {
+				// Daemon is still running and holds the callback port.
+				return fmt.Errorf("an auth session for a different organization (%s) is already in progress; wait for it to expire or complete it first", *sess.OrgId)
+			}
+		} else {
+			return resumeSession(sess, result, wait)
+		}
 	}
 
 	// Start a new flow.
@@ -218,14 +244,14 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionS
 	}
 
 	sessionId := newSessionId()
-	sess = &SessionState{
+	newSess := &SessionState{
 		SessionId: sessionId,
 		CSRFState: csrfState,
 		AuthURL:   authURL,
 		OrgId:     orgId,
 		CreatedAt: time.Now(),
 	}
-	if err := writeSessionState(*sess); err != nil {
+	if err := writeSessionState(*newSess); err != nil {
 		return fmt.Errorf("error writing session state: %w", err)
 	}
 	// Pass the PKCE verifier to the daemon via environment variable rather than
@@ -235,17 +261,22 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionS
 		return fmt.Errorf("error spawning auth daemon: %w", err)
 	}
 
-	// Print the pending JSON and exit immediately. The daemon owns the callback
-	// server and will write a result file when auth completes. The next invocation
-	// of this command will detect the pending session and poll for the result.
+	if wait {
+		// Caller needs the token on return — block until the daemon completes.
+		return pollForResult(sessionId, newSess.CreatedAt, true)
+	}
+
+	// Agentic login (first call): print pending and return immediately. The daemon
+	// owns the callback server and will write a result file when auth completes.
+	// The next invocation will detect the pending session and poll for the result.
 	printPendingJSON(authURL, sessionId)
 	return nil
 }
 
 // resumeSession handles a session that was already started (e.g. after a process restart).
-// If the daemon already finished, it handles the result immediately. Otherwise it re-prints
-// the pending URL and continues polling.
-func resumeSession(sess *SessionState, result *SessionResult) error {
+// If the daemon already finished, it handles the result immediately. Otherwise it polls.
+// When wait is true, RunPostAuthSetup is skipped; the caller owns post-auth state and output.
+func resumeSession(sess *SessionState, result *SessionResult, wait bool) error {
 	if result != nil {
 		// Daemon already completed while we were away.
 		defer CleanupSession(sess.SessionId)
@@ -253,29 +284,31 @@ func resumeSession(sess *SessionState, result *SessionResult) error {
 			return fmt.Errorf("authentication failed: %s", result.Error)
 		}
 		_ = secrets.SecretsViper.ReadInConfig()
+		if wait {
+			return nil
+		}
 		setupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		return RunPostAuthSetup(setupCtx)
 	}
-	// Still pending — poll until the daemon completes and emit authenticated JSON.
-	// Don't re-emit pending here: this call will block until done and emit exactly
-	// one JSON object (authenticated), keeping stdout to a single JSON value per invocation.
-	return pollForResult(sess.SessionId, sess.CreatedAt)
+	// Still pending — poll until the daemon completes.
+	// Don't re-emit pending here: this call will block until done, keeping stdout
+	// to a single JSON value per invocation.
+	return pollForResult(sess.SessionId, sess.CreatedAt, wait)
 }
 
 // pollForResult polls the daemon's result file until auth completes or the session expires.
-// On success it runs post-auth setup and emits the final authenticated JSON.
+// On success, when wait is false it calls RunPostAuthSetup to emit authenticated JSON;
+// when wait is true it reloads credentials and returns, leaving output to the caller.
 // On timeout it returns without cleaning up so the daemon can still complete and be
 // resumed on the next invocation.
 //
 // createdAt is the session's creation time; the deadline is computed from it so that
 // the total wait never exceeds sessionMaxAge regardless of when polling started.
 //
-// The polling loop runs on context.Background() rather than the caller's context so that
-// the root command's --timeout flag (default 60s) does not interrupt a user who is still
-// authenticating in the browser. The caller's context is passed through only to
-// RunPostAuthSetup for the subsequent API calls.
-func pollForResult(sessionId string, createdAt time.Time) error {
+// The polling loop runs on context.Background() so that the root command's --timeout
+// flag (default 60s) does not interrupt a user still authenticating in the browser.
+func pollForResult(sessionId string, createdAt time.Time, wait bool) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	remaining := time.Until(createdAt.Add(sessionMaxAge))
@@ -305,6 +338,10 @@ func pollForResult(sessionId string, createdAt time.Time) error {
 			// The daemon wrote the token to secrets.yaml from a separate process.
 			// Reload from disk so this process's Viper cache reflects it.
 			_ = secrets.SecretsViper.ReadInConfig()
+			if wait {
+				// Caller handles post-auth state and output.
+				return nil
+			}
 			// Use a fresh context for the post-auth API calls: the original ctx may
 			// have expired if the user took longer than --timeout to authenticate.
 			setupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -216,17 +216,18 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionS
 
 	sessionId := newSessionId()
 	sess = &SessionState{
-		SessionId:    sessionId,
-		PKCEVerifier: verifier,
-		CSRFState:    csrfState,
-		AuthURL:      authURL,
-		OrgId:        orgId,
-		CreatedAt:    time.Now(),
+		SessionId: sessionId,
+		CSRFState: csrfState,
+		AuthURL:   authURL,
+		OrgId:     orgId,
+		CreatedAt: time.Now(),
 	}
 	if err := writeSessionState(*sess); err != nil {
 		return fmt.Errorf("error writing session state: %w", err)
 	}
-	if err := spawnDaemon(sessionId); err != nil {
+	// Pass the PKCE verifier to the daemon via environment variable rather than
+	// writing it to the session file, so it never touches disk.
+	if err := spawnDaemon(sessionId, verifier); err != nil {
 		CleanupSession(sessionId)
 		return fmt.Errorf("error spawning auth daemon: %w", err)
 	}
@@ -481,7 +482,8 @@ func RunPostAuthSetup(ctx context.Context) error {
 }
 
 // spawnDaemon starts a detached `pc auth _daemon --session-id <id>` process.
-func spawnDaemon(sessionId string) error {
+// The PKCE verifier is passed via environment variable so it never touches disk.
+func spawnDaemon(sessionId, pkceVerifier string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("error finding executable path: %w", err)
@@ -491,6 +493,7 @@ func spawnDaemon(sessionId string) error {
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil
+	cmd.Env = append(os.Environ(), "PINECONE_PKCE_VERIFIER="+pkceVerifier)
 	return cmd.Start()
 }
 

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -46,14 +46,17 @@ func Run(ctx context.Context, opts Options) {
 	// Resolve output format once at the top level: explicit --json flag or auto-detected non-TTY stdout.
 	opts.Json = opts.Json || !term.IsTerminal(int(os.Stdout.Fd()))
 
-	// In JSON mode, a pending session means the daemon just completed and wrote
-	// the token to disk. Skip the already_authenticated guard so that
-	// getAndSetAccessTokenJSON → resumeSession → RunPostAuthSetup can run,
-	// set TargetOrg/TargetProj, emit the authenticated JSON, and clean up
-	// the session files.
+	// In JSON mode, check for a pending session once here. If found, skip the
+	// already_authenticated guard and pass the result directly into GetAndSetAccessToken
+	// to avoid a redundant directory scan and TOCTOU window.
 	if opts.Json {
-		if sess, _, _ := findResumableSession(); sess != nil {
-			if err := GetAndSetAccessToken(ctx, nil, opts); err != nil {
+		sess, result, err := findResumableSession()
+		if err != nil {
+			msg.FailMsg("Error checking for existing auth session: %s", err)
+			exit.Error(err, "Error checking for existing auth session")
+		}
+		if sess != nil {
+			if err := getAndSetAccessTokenJSON(ctx, nil, sess, result); err != nil {
 				msg.FailMsg("Error acquiring access token while logging in: %s", err)
 				exit.Error(err, "Error acquiring access token while logging in")
 			}
@@ -176,17 +179,22 @@ func Run(ctx context.Context, opts Options) {
 // function will detect the pending session and resume polling rather than starting a new flow.
 func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) error {
 	if opts.Json {
-		return getAndSetAccessTokenJSON(ctx, orgId)
+		return getAndSetAccessTokenJSON(ctx, orgId, nil, nil)
 	}
 	return getAndSetAccessTokenInteractive(ctx, orgId)
 }
 
 // getAndSetAccessTokenJSON is the agentic path: daemon-backed, non-blocking on stdin.
-func getAndSetAccessTokenJSON(ctx context.Context, orgId *string) error {
-	// Resume a pending session if one exists (e.g. this process was killed mid-poll).
-	sess, result, err := findResumableSession()
-	if err != nil {
-		return fmt.Errorf("error checking for existing auth session: %w", err)
+// sess and result may be pre-fetched by the caller to avoid a redundant directory scan;
+// if nil, findResumableSession is called here.
+func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, sess *SessionState, result *SessionResult) error {
+	if sess == nil {
+		// No pre-fetched session — look one up now.
+		var err error
+		sess, result, err = findResumableSession()
+		if err != nil {
+			return fmt.Errorf("error checking for existing auth session: %w", err)
+		}
 	}
 	if sess != nil {
 		return resumeSession(sess, result)

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -185,7 +185,10 @@ func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) erro
 func getAndSetAccessTokenJSON(ctx context.Context, orgId *string) error {
 	// Resume a pending session if one exists (e.g. this process was killed mid-poll).
 	sess, result, err := findResumableSession()
-	if err == nil && sess != nil {
+	if err != nil {
+		return fmt.Errorf("error checking for existing auth session: %w", err)
+	}
+	if sess != nil {
 		return resumeSession(sess, result)
 	}
 

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -178,6 +178,9 @@ func Run(ctx context.Context, opts Options) {
 // finishes (e.g. an agent timeout), the daemon keeps running; the next call to this
 // function will detect the pending session and resume polling rather than starting a new flow.
 func GetAndSetAccessToken(ctx context.Context, orgId *string, opts Options) error {
+	// Apply TTY auto-detection here so callers don't have to — if stdout is not
+	// a terminal (agentic context), always use the JSON/daemon path.
+	opts.Json = opts.Json || !term.IsTerminal(int(os.Stdout.Fd()))
 	if opts.Json {
 		return getAndSetAccessTokenJSON(ctx, orgId, nil, nil)
 	}

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"time"
@@ -293,12 +292,6 @@ func pollForResult(sessionId string) error {
 }
 
 func printPendingJSON(authURL, sessionId string) {
-	// Decode percent-encoded characters (e.g. %3A→: %2F→/) so the URL is
-	// human-readable when copied from the terminal. Browsers re-encode correctly.
-	displayURL, err := url.PathUnescape(authURL)
-	if err != nil {
-		displayURL = authURL
-	}
 	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
 		Status      string `json:"status"`
 		URL         string `json:"url"`
@@ -306,7 +299,7 @@ func printPendingJSON(authURL, sessionId string) {
 		Description string `json:"description"`
 	}{
 		Status:      "pending",
-		URL:         displayURL,
+		URL:         authURL,
 		SessionId:   sessionId,
 		Description: "Navigate to the URL to complete the OAuth authorization flow, then call this command again to retrieve credentials.",
 	}))

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -255,7 +255,7 @@ func resumeSession(sess *SessionState, result *SessionResult) error {
 	}
 	// Still pending — re-surface the URL and keep polling.
 	printPendingJSON(sess.AuthURL, sess.SessionId)
-	return pollForResult(sess.SessionId)
+	return pollForResult(sess.SessionId, sess.CreatedAt)
 }
 
 // pollForResult polls the daemon's result file until auth completes or the session expires.
@@ -263,14 +263,21 @@ func resumeSession(sess *SessionState, result *SessionResult) error {
 // On timeout it returns without cleaning up so the daemon can still complete and be
 // resumed on the next invocation.
 //
+// createdAt is the session's creation time; the deadline is computed from it so that
+// the total wait never exceeds sessionMaxAge regardless of when polling started.
+//
 // The polling loop runs on context.Background() rather than the caller's context so that
 // the root command's --timeout flag (default 60s) does not interrupt a user who is still
 // authenticating in the browser. The caller's context is passed through only to
 // RunPostAuthSetup for the subsequent API calls.
-func pollForResult(sessionId string) error {
+func pollForResult(sessionId string, createdAt time.Time) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	deadline := time.NewTimer(sessionMaxAge)
+	remaining := time.Until(createdAt.Add(sessionMaxAge))
+	if remaining <= 0 {
+		return errors.New("timed out waiting for authentication")
+	}
+	deadline := time.NewTimer(remaining)
 	defer deadline.Stop()
 
 	for {

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -263,6 +263,9 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, wait bool, ses
 
 	if wait {
 		// Caller needs the token on return — block until the daemon completes.
+		// Print the auth URL to stderr so the user/agent can navigate to it while
+		// we poll. Stderr keeps stdout clean for the caller's own JSON output.
+		fmt.Fprintf(os.Stderr, "Visit the following URL to authenticate:\n\n  %s\n\n", authURL)
 		return pollForResult(sessionId, newSess.CreatedAt, true)
 	}
 

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"time"
@@ -45,6 +46,21 @@ type Options struct {
 func Run(ctx context.Context, opts Options) {
 	// Resolve output format once at the top level: explicit --json flag or auto-detected non-TTY stdout.
 	opts.Json = opts.Json || !term.IsTerminal(int(os.Stdout.Fd()))
+
+	// In JSON mode, a pending session means the daemon just completed and wrote
+	// the token to disk. Skip the already_authenticated guard so that
+	// getAndSetAccessTokenJSON → resumeSession → RunPostAuthSetup can run,
+	// set TargetOrg/TargetProj, emit the authenticated JSON, and clean up
+	// the session files.
+	if opts.Json {
+		if sess, _, _ := findResumableSession(); sess != nil {
+			if err := GetAndSetAccessToken(ctx, nil, opts); err != nil {
+				msg.FailMsg("Error acquiring access token while logging in: %s", err)
+				exit.Error(err, "Error acquiring access token while logging in")
+			}
+			return
+		}
+	}
 
 	token, err := oauth.Token(ctx)
 
@@ -171,7 +187,7 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string) error {
 	// Resume a pending session if one exists (e.g. this process was killed mid-poll).
 	sess, result, err := findResumableSession()
 	if err == nil && sess != nil {
-		return resumeSession(ctx, sess, result)
+		return resumeSession(sess, result)
 	}
 
 	// Start a new flow.
@@ -215,7 +231,7 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string) error {
 // resumeSession handles a session that was already started (e.g. after a process restart).
 // If the daemon already finished, it handles the result immediately. Otherwise it re-prints
 // the pending URL and continues polling.
-func resumeSession(ctx context.Context, sess *SessionState, result *SessionResult) error {
+func resumeSession(sess *SessionState, result *SessionResult) error {
 	if result != nil {
 		// Daemon already completed while we were away.
 		defer CleanupSession(sess.SessionId)
@@ -223,18 +239,25 @@ func resumeSession(ctx context.Context, sess *SessionState, result *SessionResul
 			return fmt.Errorf("authentication failed: %s", result.Error)
 		}
 		_ = secrets.SecretsViper.ReadInConfig()
-		return RunPostAuthSetup(ctx)
+		setupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return RunPostAuthSetup(setupCtx)
 	}
 	// Still pending — re-surface the URL and keep polling.
 	printPendingJSON(sess.AuthURL, sess.SessionId)
-	return pollForResult(ctx, sess.SessionId)
+	return pollForResult(sess.SessionId)
 }
 
 // pollForResult polls the daemon's result file until auth completes or the session expires.
 // On success it runs post-auth setup and emits the final authenticated JSON.
 // On timeout it returns without cleaning up so the daemon can still complete and be
 // resumed on the next invocation.
-func pollForResult(ctx context.Context, sessionId string) error {
+//
+// The polling loop runs on context.Background() rather than the caller's context so that
+// the root command's --timeout flag (default 60s) does not interrupt a user who is still
+// authenticating in the browser. The caller's context is passed through only to
+// RunPostAuthSetup for the subsequent API calls.
+func pollForResult(sessionId string) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	deadline := time.NewTimer(sessionMaxAge)
@@ -242,8 +265,6 @@ func pollForResult(ctx context.Context, sessionId string) error {
 
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
 		case <-deadline.C:
 			// Don't clean up — daemon may still complete; next call will resume.
 			return errors.New("timed out waiting for authentication")
@@ -262,17 +283,33 @@ func pollForResult(ctx context.Context, sessionId string) error {
 			// The daemon wrote the token to secrets.yaml from a separate process.
 			// Reload from disk so this process's Viper cache reflects it.
 			_ = secrets.SecretsViper.ReadInConfig()
-			return RunPostAuthSetup(ctx)
+			// Use a fresh context for the post-auth API calls: the original ctx may
+			// have expired if the user took longer than --timeout to authenticate.
+			setupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			return RunPostAuthSetup(setupCtx)
 		}
 	}
 }
 
 func printPendingJSON(authURL, sessionId string) {
+	// Decode percent-encoded characters (e.g. %3A→: %2F→/) so the URL is
+	// human-readable when copied from the terminal. Browsers re-encode correctly.
+	displayURL, err := url.PathUnescape(authURL)
+	if err != nil {
+		displayURL = authURL
+	}
 	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
-		Status    string `json:"status"`
-		URL       string `json:"url"`
-		SessionId string `json:"session_id"`
-	}{Status: "pending", URL: authURL, SessionId: sessionId}))
+		Status      string `json:"status"`
+		URL         string `json:"url"`
+		SessionId   string `json:"session_id"`
+		Description string `json:"description"`
+	}{
+		Status:      "pending",
+		URL:         displayURL,
+		SessionId:   sessionId,
+		Description: "Navigate to the URL to complete the OAuth authorization flow, then call this command again to retrieve credentials.",
+	}))
 }
 
 // getAndSetAccessTokenInteractive is the original interactive path: inline callback server,
@@ -408,6 +445,7 @@ func RunPostAuthSetup(ctx context.Context) error {
 	})
 
 	projectId := ""
+	projectName := ""
 	if len(projects) > 0 {
 		targetProj := projects[0]
 		state.TargetProj.Set(state.TargetProject{
@@ -415,14 +453,17 @@ func RunPostAuthSetup(ctx context.Context) error {
 			Id:   targetProj.Id,
 		})
 		projectId = targetProj.Id
+		projectName = targetProj.Name
 	}
 
 	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
-		Status    string `json:"status"`
-		Email     string `json:"email"`
-		OrgId     string `json:"org_id"`
-		ProjectId string `json:"project_id"`
-	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, ProjectId: projectId}))
+		Status      string `json:"status"`
+		Email       string `json:"email"`
+		OrgId       string `json:"org_id"`
+		OrgName     string `json:"org_name"`
+		ProjectId   string `json:"project_id"`
+		ProjectName string `json:"project_name"`
+	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, OrgName: targetOrg.Name, ProjectId: projectId, ProjectName: projectName}))
 
 	return nil
 }

--- a/internal/pkg/utils/login/process_unix.go
+++ b/internal/pkg/utils/login/process_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package login
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess configures cmd to run as a new session leader so it is not
+// killed when the parent process exits or its controlling terminal closes.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/pkg/utils/login/process_windows.go
+++ b/internal/pkg/utils/login/process_windows.go
@@ -7,10 +7,11 @@ import (
 	"syscall"
 )
 
-// detachProcess configures cmd to run in its own process group so it is not
-// killed when the parent process exits.
+// detachProcess configures cmd to run detached from the parent's console session.
+// CREATE_NEW_PROCESS_GROUP prevents Ctrl+C propagation; DETACHED_PROCESS (0x00000008)
+// detaches the child from the parent's console so it survives terminal close.
 func detachProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | 0x00000008,
 	}
 }

--- a/internal/pkg/utils/login/process_windows.go
+++ b/internal/pkg/utils/login/process_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package login
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess configures cmd to run in its own process group so it is not
+// killed when the parent process exits.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/internal/pkg/utils/login/session.go
+++ b/internal/pkg/utils/login/session.go
@@ -91,7 +91,28 @@ func WriteSessionResult(r SessionResult) error {
 	if err != nil {
 		return fmt.Errorf("error marshaling session result: %w", err)
 	}
-	return os.WriteFile(path, data, 0600)
+	// Write to a temp file in the same directory, then rename for atomicity.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".result-*.tmp")
+	if err != nil {
+		return fmt.Errorf("error creating temp result file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("error writing temp result file: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("error setting permissions on temp result file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("error closing temp result file: %w", err)
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func readSessionResult(sessionId string) (*SessionResult, error) {
@@ -108,7 +129,8 @@ func readSessionResult(sessionId string) (*SessionResult, error) {
 	}
 	var r SessionResult
 	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, fmt.Errorf("error unmarshaling session result: %w", err)
+		// Partial write in progress — treat as not ready yet.
+		return nil, nil
 	}
 	return &r, nil
 }

--- a/internal/pkg/utils/login/session.go
+++ b/internal/pkg/utils/login/session.go
@@ -13,12 +13,11 @@ import (
 )
 
 type SessionState struct {
-	SessionId    string    `json:"session_id"`
-	PKCEVerifier string    `json:"pkce_verifier"`
-	CSRFState    string    `json:"csrf_state"`
-	AuthURL      string    `json:"auth_url"`
-	OrgId        *string   `json:"org_id,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
+	SessionId string    `json:"session_id"`
+	CSRFState string    `json:"csrf_state"`
+	AuthURL   string    `json:"auth_url"`
+	OrgId     *string   `json:"org_id,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type SessionResult struct {

--- a/internal/pkg/utils/login/session.go
+++ b/internal/pkg/utils/login/session.go
@@ -1,0 +1,173 @@
+package login
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/configuration"
+)
+
+type SessionState struct {
+	SessionId    string    `json:"session_id"`
+	PKCEVerifier string    `json:"pkce_verifier"`
+	CSRFState    string    `json:"csrf_state"`
+	AuthURL      string    `json:"auth_url"`
+	OrgId        *string   `json:"org_id,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type SessionResult struct {
+	SessionId   string    `json:"session_id"`
+	Status      string    `json:"status"` // "success" or "error"
+	Error       string    `json:"error,omitempty"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+const sessionMaxAge = 5 * time.Minute
+
+func sessionsDir() (string, error) {
+	dir := filepath.Join(configuration.ConfigDirPath(), "sessions")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("error creating sessions directory: %w", err)
+	}
+	return dir, nil
+}
+
+func sessionStatePath(sessionId string) (string, error) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sessionId+".json"), nil
+}
+
+func sessionResultPath(sessionId string) (string, error) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sessionId+".result"), nil
+}
+
+func writeSessionState(s SessionState) error {
+	path, err := sessionStatePath(s.SessionId)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("error marshaling session state: %w", err)
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func ReadSessionState(sessionId string) (*SessionState, error) {
+	path, err := sessionStatePath(sessionId)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading session state: %w", err)
+	}
+	var s SessionState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("error unmarshaling session state: %w", err)
+	}
+	return &s, nil
+}
+
+func WriteSessionResult(r SessionResult) error {
+	path, err := sessionResultPath(r.SessionId)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("error marshaling session result: %w", err)
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func readSessionResult(sessionId string) (*SessionResult, error) {
+	path, err := sessionResultPath(sessionId)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // not complete yet
+		}
+		return nil, fmt.Errorf("error reading session result: %w", err)
+	}
+	var r SessionResult
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("error unmarshaling session result: %w", err)
+	}
+	return &r, nil
+}
+
+func CleanupSession(sessionId string) {
+	statePath, _ := sessionStatePath(sessionId)
+	resultPath, _ := sessionResultPath(sessionId)
+	_ = os.Remove(statePath)
+	_ = os.Remove(resultPath)
+}
+
+// findResumableSession looks for a recent pending session that can be resumed.
+// Returns the session state and its result (nil if still pending), or nil if
+// no resumable session exists.
+func findResumableSession() (*SessionState, *SessionResult, error) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading sessions directory: %w", err)
+	}
+
+	var newest *SessionState
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		id := e.Name()[:len(e.Name())-len(".json")]
+		s, err := ReadSessionState(id)
+		if err != nil {
+			continue
+		}
+		if time.Since(s.CreatedAt) > sessionMaxAge {
+			// Stale — clean it up
+			CleanupSession(s.SessionId)
+			continue
+		}
+		if newest == nil || s.CreatedAt.After(newest.CreatedAt) {
+			newest = s
+		}
+	}
+
+	if newest == nil {
+		return nil, nil, nil
+	}
+
+	result, err := readSessionResult(newest.SessionId)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return newest, result, nil
+}
+
+func newSessionId() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}


### PR DESCRIPTION
Reworks the OAuth login flow to work correctly in agentic contexts (Claude Code, Cursor, other AI coding agents) where stdin/stdout are not interactive TTYs.                                       
                                                                                                  
### Problem                                                        

The previous `pc login` flow blocked on stdin waiting for `[Enter]`, and the auth URL was either hidden or percent-encoded in ways that made it hard for agents to extract. There was no machine-readable way to surface the URL and get a non-blocking result.                            
                                                                   
### Solution: daemon-backed two-call pattern                                                      
 
**First call** (`pc login --json`): spawns a detached background daemon that owns the OAuth callback server on `127.0.0.1:59049`, emits `{"status":"pending","url":"...","session_id":"..."}` to stdout, and exits immediately. The daemon keeps listening for the browser redirect.
                                                                   
**Second call** (`pc login --json`): detects the pending session, polls the daemon's result file until auth completes, then emits `{"status":"authenticated","email":"...","org_id":"...","org_name":"...","project_id":"...","project_name":"..."}`.                                                
                                                                   
If the second call is killed before the daemon finishes, a third call resumes seamlessly — the daemon keeps running regardless.

Non-agentic users (`pc login` without `--json`, TTY stdout) are completely unaffected.    
 
### Key details                                                                                   
- **Session state** is stored in `~/.config/pinecone/sessions/` (mode 0600, 5-minute TTL) — PKCE verifier is passed to the daemon via environment variable and never touches disk.
- **Atomic result writes** use write-to-temp-then-rename to prevent partial reads in the polling loop.
- **`pc target` re-auth** uses a `Wait: true` mode that blocks until the token is acquired (daemon path, but synchronous), printing the auth URL to stderr so it's visible without polluting stdout.
- **Windows** daemon uses `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS` so it survives terminal close.
- **TTY auto-detection** is applied in `GetAndSetAccessToken` so all callers (including `pc target`) correctly use the daemon path in non-TTY environments.
- **Port conflict detection** in the interactive path surfaces a clear error with the existing auth URL if a daemon is already holding the callback port.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI OAuth login flow to spawn a detached background process and persist session state/results on disk, which can impact authentication reliability across platforms and failure modes. Also modifies re-auth behavior in `pc target` to block until tokens are acquired.
> 
> **Overview**
> **Daemonizes `pc login --json` OAuth flow** by introducing a hidden `pc auth _daemon` subcommand that runs the local callback server in a detached process, exchanges the auth code, stores the token, and writes a session result file.
> 
> **Adds resumable, file-backed login sessions** (`sessions/` state+result) so JSON login can return immediately with `{"status":"pending"...}` and be polled/resumed on subsequent invocations, with cleanup/expiry handling and cross-platform process detachment.
> 
> **Refactors token acquisition and post-auth setup**: splits interactive vs JSON paths, adds `Options.Wait` for callers that must block until credentials exist, and updates `pc target` re-auth to use `Wait: true` while keeping JSON output behavior separate via `RunPostAuthSetup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 596f6764283d8525f3912100ff7d550f38fa5fd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->