### PR TITLE
Agentic auth improvements: lazy login, `--json` consistency, and `pc target` fixes

### DIFF
--- a/internal/pkg/cli/command/auth/login.go
+++ b/internal/pkg/cli/command/auth/login.go
@@ -17,12 +17,33 @@ var (
 		organizations, projects, and other account-level resources directly
 		from the command line), as well as control and data plane operations.
 
-		Running this command opens a browser to the Pinecone login page.
-		After you successfully authenticate, the CLI is automatically configured with a
+		INTERACTIVE MODE (default)
+
+		Opens a browser to the Pinecone login page and waits for you to complete
+		authentication. Once complete, the CLI is automatically configured with a
 		default target organization and project.
-		
-		You can view your current target with 'pc target -s' or change it at any
-		time with 'pc target -o "ORGANIZATION_NAME" -p "PROECT_NAME"'.
+
+		You can view your current target with 'pc target --show' or change it at
+		any time with 'pc target --org "ORG_NAME" --project "PROJECT_NAME"'.
+
+		AGENTIC / NON-INTERACTIVE MODE (--json / -j, or non-TTY stdout)
+
+		Uses a daemon-backed two-call flow designed for AI agents and scripts:
+
+		First call — starts a background listener and returns immediately:
+		  {"status":"pending","url":"<auth-url>","session_id":"<id>"}
+
+		Open the URL in a browser to complete authentication. The background
+		listener captures the OAuth callback automatically.
+
+		Second call (or any other command) — completes the flow:
+		  {"status":"authenticated","email":"...","org_id":"...","org_name":"...","project_id":"...","project_name":"..."}
+
+		If the process is interrupted between calls, the background listener keeps
+		running. The next invocation detects the pending session and resumes
+		automatically. After authentication is complete, the first subsequent
+		command also sets the target context automatically, so a separate
+		'pc target' call is not required.
 	`)
 )
 
@@ -34,7 +55,14 @@ func NewLoginCmd() *cobra.Command {
 		Short: "Authenticate with Pinecone via user login in a web browser",
 		Long:  loginHelp,
 		Example: help.Examples(`
+			# Interactive login (opens a browser)
 			pc auth login
+
+			# Agentic login — first call returns a pending URL
+			pc auth login --json
+
+			# Agentic login — second call (or any command) completes the flow
+			pc auth login --json
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/auth/login.go
+++ b/internal/pkg/cli/command/auth/login.go
@@ -42,7 +42,7 @@ func NewLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON output")
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "emit JSON output")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -34,7 +34,7 @@ func NewLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON output")
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "emit JSON output")
 
 	return cmd
 }

--- a/internal/pkg/cli/command/login/login.go
+++ b/internal/pkg/cli/command/login/login.go
@@ -12,9 +12,30 @@ var (
 	loginHelp = help.Long(`
 		Authenticate with Pinecone via user login in a web browser.
 
-		After logging in, the CLI automatically sets a target organization and project. However, you can 
-		set a new target organization or project using 'pc target' before accessing control
-		and data plane resources.
+		INTERACTIVE MODE (default)
+
+		Opens a browser to the Pinecone login page and waits for you to complete
+		authentication. The CLI automatically sets a default target organization
+		and project. Use 'pc target' to change the target at any time.
+
+		AGENTIC / NON-INTERACTIVE MODE (--json / -j, or non-TTY stdout)
+
+		Uses a daemon-backed two-call flow designed for AI agents and scripts:
+
+		First call — starts a background listener and returns immediately:
+		  {"status":"pending","url":"<auth-url>","session_id":"<id>"}
+
+		Open the URL in a browser to complete authentication. The background
+		listener captures the OAuth callback automatically.
+
+		Second call (or any other command) — completes the flow:
+		  {"status":"authenticated","email":"...","org_id":"...","org_name":"...","project_id":"...","project_name":"..."}
+
+		If the process is interrupted between calls, the background listener keeps
+		running. The next invocation detects the pending session and resumes
+		automatically. After authentication is complete, the first subsequent
+		command also sets the target context automatically, so a separate
+		'pc target' call is not required.
 	`)
 )
 
@@ -26,7 +47,14 @@ func NewLoginCmd() *cobra.Command {
 		Short: "Authenticate with Pinecone via user login in a web browser",
 		Long:  loginHelp,
 		Example: help.Examples(`
+			# Interactive login (opens a browser)
 			pc login
+
+			# Agentic login — first call returns a pending URL
+			pc login --json
+
+			# Agentic login — second call (or any command) completes the flow
+			pc login --json
 		`),
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/term"
+
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/apiKey"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/auth"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/backup"
@@ -20,7 +22,10 @@ import (
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/target"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/version"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/whoami"
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	loginutil "github.com/pinecone-io/cli/internal/pkg/utils/login"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +34,26 @@ var (
 	globalOptions  GlobalOptions
 	cancelRootFunc context.CancelFunc
 )
+
+// skipAuthCommands lists the full command paths that do not require authentication.
+// These are commands that either establish credentials or work on local state only.
+// When adding new commands that don't need auth, add their CommandPath() here.
+var skipAuthCommands = map[string]struct{}{
+	"pc login":                   {},
+	"pc logout":                  {},
+	"pc auth login":              {},
+	"pc auth logout":             {},
+	"pc auth configure":          {},
+	"pc auth clear":              {},
+	"pc auth status":             {},
+	"pc auth _daemon":            {},
+	"pc version":                 {},
+	"pc config":                  {},
+	"pc config get-api-key":      {},
+	"pc config set-api-key":      {},
+	"pc config set-color":        {},
+	"pc config set-environment":  {},
+}
 
 type GlobalOptions struct {
 	timeout time.Duration
@@ -88,6 +113,23 @@ func init() {
 				ctx, cancel := context.WithTimeout(cmd.Context(), globalOptions.timeout)
 				cancelRootFunc = cancel
 				cmd.SetContext(ctx)
+			}
+
+			// Skip auth check for commands that establish or manage credentials.
+			if _, skip := skipAuthCommands[cmd.CommandPath()]; skip {
+				return
+			}
+
+			// JSON mode: non-TTY stdout OR the command's own --json/-j flag was set.
+			isJSON := !term.IsTerminal(int(os.Stdout.Fd()))
+			if !isJSON {
+				if f := cmd.Flags().Lookup("json"); f != nil && f.Value.String() == "true" {
+					isJSON = true
+				}
+			}
+			if err := loginutil.EnsureAuthenticated(cmd.Context()); err != nil {
+				msg.FailJSON(isJSON, "%s", err)
+				exit.Error(err, "authentication required")
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -47,6 +47,7 @@ var skipAuthCommands = map[string]struct{}{
 	"pc auth clear":              {},
 	"pc auth status":             {},
 	"pc auth _daemon":            {},
+	"pc target":                  {}, // handles its own auth after --show/--clear early returns
 	"pc version":                 {},
 	"pc config":                  {},
 	"pc config get-api-key":      {},

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -133,6 +133,7 @@ func init() {
 			if err := loginutil.EnsureAuthenticated(cmd.Context()); err != nil {
 				msg.FailJSON(isJSON, "%s", err)
 				exit.Error(err, "authentication required")
+				return
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -47,6 +47,8 @@ var skipAuthCommands = map[string]struct{}{
 	"pc auth clear":              {},
 	"pc auth status":             {},
 	"pc auth _daemon":            {},
+	"pc auth local-keys":         {}, // parent command (shows help)
+	"pc auth local-keys list":    {}, // reads local state only, no API calls
 	"pc target":                  {}, // handles its own auth after --show/--clear early returns
 	"pc version":                 {},
 	"pc config":                  {},

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -100,11 +100,7 @@ func NewTargetCmd() *cobra.Command {
 			if options.show {
 				if options.json {
 					log.Info().Msg("Outputting target context as JSON")
-					targetContext := state.GetTargetContext()
-					defaultAPIKey := secrets.DefaultAPIKey.Get()
-					targetContext.DefaultAPIKey = presenters.MaskHeadTail(defaultAPIKey, 4, 4)
-					json := text.IndentJSON(targetContext)
-					fmt.Fprintln(os.Stdout, json)
+					printTargetContextJSON()
 					return
 				}
 				log.Info().
@@ -114,8 +110,19 @@ func NewTargetCmd() *cobra.Command {
 				return
 			}
 
-			// --show and --clear are local-state operations that return above.
-			// Everything below requires valid credentials, so check now.
+			// In JSON mode with no targeting flags, show current context — same as
+			// --show --json. This is a local-state read with no API calls needed.
+			if options.json &&
+				options.org == "" &&
+				options.orgID == "" &&
+				options.project == "" &&
+				options.projectID == "" {
+				printTargetContextJSON()
+				return
+			}
+
+			// --show, --clear, and the no-flags JSON path are local-state operations
+			// that return above. Everything below requires valid credentials.
 			if err := login.EnsureAuthenticated(ctx); err != nil {
 				msg.FailJSON(options.json, "%s", err)
 				exit.Error(err, "authentication required")
@@ -155,16 +162,6 @@ func NewTargetCmd() *cobra.Command {
 				options.orgID == "" &&
 				options.project == "" &&
 				options.projectID == "" {
-
-				if options.json {
-					// In non-TTY/JSON mode there's no interactive selector — just
-					// show the current target context so agents can read it.
-					targetContext := state.GetTargetContext()
-					defaultAPIKey := secrets.DefaultAPIKey.Get()
-					targetContext.DefaultAPIKey = presenters.MaskHeadTail(defaultAPIKey, 4, 4)
-					fmt.Fprintln(os.Stdout, text.IndentJSON(targetContext))
-					return
-				}
 
 				// Ask the user to choose a target org
 				targetOrg := postLoginInteractiveTargetOrg(orgs, options.json)
@@ -276,11 +273,7 @@ func NewTargetCmd() *cobra.Command {
 
 			// Output JSON if the option was passed
 			if options.json {
-				targetContext := state.GetTargetContext()
-				defaultAPIKey := secrets.DefaultAPIKey.Get()
-				targetContext.DefaultAPIKey = presenters.MaskHeadTail(defaultAPIKey, 4, 4)
-				json := text.IndentJSON(targetContext)
-				fmt.Fprintln(os.Stdout, json)
+				printTargetContextJSON()
 				return
 			}
 
@@ -300,6 +293,12 @@ func NewTargetCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")
 
 	return cmd
+}
+
+func printTargetContextJSON() {
+	targetContext := state.GetTargetContext()
+	targetContext.DefaultAPIKey = presenters.MaskHeadTail(secrets.DefaultAPIKey.Get(), 4, 4)
+	fmt.Fprintln(os.Stdout, text.IndentJSON(targetContext))
 }
 
 func validateTargetOptions(options targetCmdOptions) error {

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -43,16 +43,40 @@ var (
 		After authenticating through the CLI with user login or service account credentials, you can use
 		this command to set the target organization or project context for control and data plane operations.
 
-		When using a default API key for authentication, there's no need to specify a project context, because the API 
+		When using a default API key for authentication, there's no need to specify a project context, because the API
 		key is already associated with a specific organization and project.
+
+		INTERACTIVE MODE (default, TTY only)
+
+		Running without flags launches an interactive selector to choose an
+		organization and project from your account.
+
+		NON-INTERACTIVE / AGENTIC MODE
+
+		Pass --org, --project, --organization-id, or --project-id to set the
+		target programmatically without a TTY. Use --json / -j to receive the
+		updated context as a JSON object.
+
+		Running with --json and no targeting flags shows the current target
+		context as JSON (equivalent to --show --json). This works without
+		authentication and is safe to call at any time to inspect state.
+
+		--show and --clear are local-state operations and do not require
+		authentication.
 	`)
 
 	targetExample = help.Examples(`
 		# Interactively target from available organizations and projects
 		pc target
 
+		# Show the current target context
+		pc target --show
+
+		# Show the current target context as JSON (no auth required)
+		pc target --json
+
 		# Target an organization and project by name
-		pc target --org "organization-name" -project "project-name"
+		pc target --org "organization-name" --project "project-name"
 
 		# Target a project by name
 		pc target --project "project-name"

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -126,6 +126,7 @@ func NewTargetCmd() *cobra.Command {
 			if err := login.EnsureAuthenticated(ctx); err != nil {
 				msg.FailJSON(options.json, "%s", err)
 				exit.Error(err, "authentication required")
+				return
 			}
 
 			// Get the current access token and parse the orgID from the claims

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -114,6 +114,13 @@ func NewTargetCmd() *cobra.Command {
 				return
 			}
 
+			// --show and --clear are local-state operations that return above.
+			// Everything below requires valid credentials, so check now.
+			if err := login.EnsureAuthenticated(ctx); err != nil {
+				msg.FailJSON(options.json, "%s", err)
+				exit.Error(err, "authentication required")
+			}
+
 			// Get the current access token and parse the orgID from the claims
 			token, err := oauth.Token(cmd.Context())
 			if err != nil {

--- a/internal/pkg/cli/command/target/target.go
+++ b/internal/pkg/cli/command/target/target.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
 
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/secrets"
 	"github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
@@ -72,6 +73,8 @@ func NewTargetCmd() *cobra.Command {
 		GroupID: help.GROUP_AUTH.ID,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			// Auto-detect non-TTY (agentic) environments just as the login flow does.
+			options.json = options.json || !term.IsTerminal(int(os.Stdout.Fd()))
 			log.Debug().
 				Str("org", options.org).
 				Str("project", options.project).
@@ -145,6 +148,16 @@ func NewTargetCmd() *cobra.Command {
 				options.orgID == "" &&
 				options.project == "" &&
 				options.projectID == "" {
+
+				if options.json {
+					// In non-TTY/JSON mode there's no interactive selector — just
+					// show the current target context so agents can read it.
+					targetContext := state.GetTargetContext()
+					defaultAPIKey := secrets.DefaultAPIKey.Get()
+					targetContext.DefaultAPIKey = presenters.MaskHeadTail(defaultAPIKey, 4, 4)
+					fmt.Fprintln(os.Stdout, text.IndentJSON(targetContext))
+					return
+				}
 
 				// Ask the user to choose a target org
 				targetOrg := postLoginInteractiveTargetOrg(orgs, options.json)

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -263,14 +263,8 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, wait bool, ses
 
 	if wait {
 		// Caller needs the token on return — block until the daemon completes.
-		// Emit the auth URL to stdout as JSON so agents watching stdout can extract
-		// it. Also write to stderr for human users. The caller is responsible for
-		// emitting its own JSON result once this function returns.
-		fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
-			Status    string `json:"status"`
-			URL       string `json:"url"`
-			SessionId string `json:"session_id"`
-		}{Status: "authenticating", URL: authURL, SessionId: sessionId}))
+		// Print the auth URL to stderr only: stdout must stay clean so the caller
+		// can emit a single JSON document once this function returns.
 		fmt.Fprintf(os.Stderr, "Visit the following URL to authenticate:\n\n  %s\n\n", authURL)
 		return pollForResult(sessionId, newSess.CreatedAt, true)
 	}

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -487,27 +487,29 @@ func getAndSetAccessTokenInteractive(ctx context.Context, orgId *string) error {
 }
 
 // applyAuthContext fetches the user's org/project and writes them to state.
-// It is the side-effect half of the post-auth setup, separated so that callers
-// that don't want to emit JSON (e.g. EnsureAuthenticated) can still set context.
-func applyAuthContext(ctx context.Context) error {
+// It returns the authenticated user's email so callers can use it without a
+// second token fetch. It is the side-effect half of the post-auth setup,
+// separated so that callers that don't want to emit JSON (e.g.
+// EnsureAuthenticated) can still set context.
+func applyAuthContext(ctx context.Context) (email string, err error) {
 	token, err := oauth.Token(ctx)
 	if err != nil {
-		return fmt.Errorf("error retrieving oauth token: %w", err)
+		return "", fmt.Errorf("error retrieving oauth token: %w", err)
 	}
 	claims, err := oauth.ParseClaimsUnverified(token)
 	if err != nil {
-		return fmt.Errorf("error parsing token claims: %w", err)
+		return "", fmt.Errorf("error parsing token claims: %w", err)
 	}
 
 	ac := sdk.NewPineconeAdminClient(ctx)
 
 	orgs, err := ac.Organization.List(ctx)
 	if err != nil {
-		return fmt.Errorf("error fetching organizations: %w", err)
+		return "", fmt.Errorf("error fetching organizations: %w", err)
 	}
 	projects, err := ac.Project.List(ctx)
 	if err != nil {
-		return fmt.Errorf("error fetching projects: %w", err)
+		return "", fmt.Errorf("error fetching projects: %w", err)
 	}
 
 	var targetOrg *pinecone.Organization
@@ -518,7 +520,7 @@ func applyAuthContext(ctx context.Context) error {
 		}
 	}
 	if targetOrg == nil {
-		return fmt.Errorf("target organization %s not found", claims.OrgId)
+		return "", fmt.Errorf("target organization %s not found", claims.OrgId)
 	}
 
 	state.TargetOrg.Set(state.TargetOrganization{
@@ -538,23 +540,15 @@ func applyAuthContext(ctx context.Context) error {
 		state.TargetProj.Set(state.TargetProject{})
 	}
 
-	return nil
+	return claims.Email, nil
 }
 
 // RunPostAuthSetup fetches the user's org/project context, sets target defaults,
 // and emits the final {"status":"authenticated",...} JSON.
 func RunPostAuthSetup(ctx context.Context) error {
-	if err := applyAuthContext(ctx); err != nil {
+	email, err := applyAuthContext(ctx)
+	if err != nil {
 		return err
-	}
-
-	token, err := oauth.Token(ctx)
-	if err != nil {
-		return fmt.Errorf("error retrieving oauth token: %w", err)
-	}
-	claims, err := oauth.ParseClaimsUnverified(token)
-	if err != nil {
-		return fmt.Errorf("error parsing token claims: %w", err)
 	}
 
 	targetOrg := state.TargetOrg.Get()
@@ -567,7 +561,7 @@ func RunPostAuthSetup(ctx context.Context) error {
 		OrgName     string `json:"org_name"`
 		ProjectId   string `json:"project_id"`
 		ProjectName string `json:"project_name"`
-	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, OrgName: targetOrg.Name, ProjectId: targetProj.Id, ProjectName: targetProj.Name}))
+	}{Status: "authenticated", Email: email, OrgId: targetOrg.Id, OrgName: targetOrg.Name, ProjectId: targetProj.Id, ProjectName: targetProj.Name}))
 
 	return nil
 }
@@ -691,7 +685,7 @@ func EnsureAuthenticated(ctx context.Context) error {
 		// login before a second `pc login` call was made), initialize the context now
 		// so the calling command doesn't fail with "need to target a project".
 		if state.TargetOrg.Get().Id == "" {
-			if err := applyAuthContext(ctx); err != nil {
+			if _, err := applyAuthContext(ctx); err != nil {
 				log.Debug().Err(err).Msg("EnsureAuthenticated: applyAuthContext failed")
 			}
 		}
@@ -727,7 +721,7 @@ func EnsureAuthenticated(ctx context.Context) error {
 	// then set the target org/project context so the calling command can proceed
 	// without a separate `pc login` or `pc target` call.
 	_ = secrets.SecretsViper.ReadInConfig()
-	if err := applyAuthContext(ctx); err != nil {
+	if _, err := applyAuthContext(ctx); err != nil {
 		// Non-fatal: credentials are valid, context setup is best-effort.
 		log.Debug().Err(err).Msg("EnsureAuthenticated: applyAuthContext failed after lazy credential reload")
 	}

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -263,8 +263,14 @@ func getAndSetAccessTokenJSON(ctx context.Context, orgId *string, wait bool, ses
 
 	if wait {
 		// Caller needs the token on return — block until the daemon completes.
-		// Print the auth URL to stderr so the user/agent can navigate to it while
-		// we poll. Stderr keeps stdout clean for the caller's own JSON output.
+		// Emit the auth URL to stdout as JSON so agents watching stdout can extract
+		// it. Also write to stderr for human users. The caller is responsible for
+		// emitting its own JSON result once this function returns.
+		fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
+			Status    string `json:"status"`
+			URL       string `json:"url"`
+			SessionId string `json:"session_id"`
+		}{Status: "authenticating", URL: authURL, SessionId: sessionId}))
 		fmt.Fprintf(os.Stderr, "Visit the following URL to authenticate:\n\n  %s\n\n", authURL)
 		return pollForResult(sessionId, newSess.CreatedAt, true)
 	}
@@ -480,9 +486,10 @@ func getAndSetAccessTokenInteractive(ctx context.Context, orgId *string) error {
 	return nil
 }
 
-// RunPostAuthSetup fetches the user's org/project context, sets target defaults,
-// and emits the final {"status":"authenticated",...} JSON.
-func RunPostAuthSetup(ctx context.Context) error {
+// applyAuthContext fetches the user's org/project and writes them to state.
+// It is the side-effect half of the post-auth setup, separated so that callers
+// that don't want to emit JSON (e.g. EnsureAuthenticated) can still set context.
+func applyAuthContext(ctx context.Context) error {
 	token, err := oauth.Token(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving oauth token: %w", err)
@@ -519,17 +526,35 @@ func RunPostAuthSetup(ctx context.Context) error {
 		Id:   targetOrg.Id,
 	})
 
-	projectId := ""
-	projectName := ""
 	if len(projects) > 0 {
 		targetProj := projects[0]
 		state.TargetProj.Set(state.TargetProject{
 			Name: targetProj.Name,
 			Id:   targetProj.Id,
 		})
-		projectId = targetProj.Id
-		projectName = targetProj.Name
 	}
+
+	return nil
+}
+
+// RunPostAuthSetup fetches the user's org/project context, sets target defaults,
+// and emits the final {"status":"authenticated",...} JSON.
+func RunPostAuthSetup(ctx context.Context) error {
+	if err := applyAuthContext(ctx); err != nil {
+		return err
+	}
+
+	token, err := oauth.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("error retrieving oauth token: %w", err)
+	}
+	claims, err := oauth.ParseClaimsUnverified(token)
+	if err != nil {
+		return fmt.Errorf("error parsing token claims: %w", err)
+	}
+
+	targetOrg := state.TargetOrg.Get()
+	targetProj := state.TargetProj.Get()
 
 	fmt.Fprintln(os.Stdout, text.IndentJSON(struct {
 		Status      string `json:"status"`
@@ -538,7 +563,7 @@ func RunPostAuthSetup(ctx context.Context) error {
 		OrgName     string `json:"org_name"`
 		ProjectId   string `json:"project_id"`
 		ProjectName string `json:"project_name"`
-	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, OrgName: targetOrg.Name, ProjectId: projectId, ProjectName: projectName}))
+	}{Status: "authenticated", Email: claims.Email, OrgId: targetOrg.Id, OrgName: targetOrg.Name, ProjectId: targetProj.Id, ProjectName: targetProj.Name}))
 
 	return nil
 }
@@ -626,6 +651,81 @@ func renderHTML(w http.ResponseWriter, htmlTemplate string, data map[string]temp
 	w.WriteHeader(http.StatusOK)
 	if err := tmpl.Execute(w, data); err != nil {
 		return fmt.Errorf("error executing auth response HTML template: %w", err)
+	}
+	return nil
+}
+
+// EnsureAuthenticated verifies that valid credentials are available, transparently
+// completing a finished pending session if one exists.
+//
+//   - Valid token or non-OAuth credentials present → returns nil immediately.
+//   - Pending session whose daemon has already completed → reloads credentials from
+//     disk and returns nil. This is the "lazy completion" path: after a successful
+//     browser login the next command just works without a second `pc login` call.
+//   - Pending session still in progress → returns an error containing the auth URL.
+//   - No credentials and no session → returns a "not authenticated" error.
+func EnsureAuthenticated(ctx context.Context) error {
+	// Service-account and API key credentials don't use OAuth tokens.
+	if secrets.ClientId.Get() != "" && secrets.ClientSecret.Get() != "" {
+		return nil
+	}
+	if secrets.DefaultAPIKey.Get() != "" {
+		return nil
+	}
+
+	// Check for a valid OAuth token.
+	token, err := oauth.Token(ctx)
+	var te *oauth.TokenError
+	if err != nil {
+		if !errors.As(err, &te) || te.Kind != oauth.TokenErrSessionExpired {
+			// Real error (network failure, etc.) — propagate it.
+			return err
+		}
+		// Session expired — fall through to check for a pending session.
+	} else if token != nil && token.AccessToken != "" {
+		// Valid token. If no target org is set yet (e.g. first command after a fresh
+		// login before a second `pc login` call was made), initialize the context now
+		// so the calling command doesn't fail with "need to target a project".
+		if state.TargetOrg.Get().Id == "" {
+			if err := applyAuthContext(ctx); err != nil {
+				log.Debug().Err(err).Msg("EnsureAuthenticated: applyAuthContext failed")
+			}
+		}
+		return nil
+	}
+
+	// No valid token — look for a pending session whose daemon may have finished.
+	sess, result, sessErr := findResumableSession()
+	if sessErr != nil {
+		return fmt.Errorf("error checking auth session: %w", sessErr)
+	}
+
+	if sess == nil {
+		if err != nil {
+			// Token was expired and there's no pending session to fall back to.
+			return err
+		}
+		return fmt.Errorf("not authenticated. Run %s to log in.", style.Code("pc login"))
+	}
+
+	if result == nil {
+		// Daemon still running — auth not yet complete.
+		return fmt.Errorf("authentication in progress. Visit the following URL to complete login, then retry:\n\n  %s\n\nOr run %s to check status.", sess.AuthURL, style.Code("pc login -j"))
+	}
+
+	// Daemon finished.
+	defer CleanupSession(sess.SessionId)
+	if result.Status == "error" {
+		return fmt.Errorf("authentication failed: %s. Run %s to try again.", result.Error, style.Code("pc login"))
+	}
+
+	// Reload credentials written by the daemon process into this process's cache,
+	// then set the target org/project context so the calling command can proceed
+	// without a separate `pc login` or `pc target` call.
+	_ = secrets.SecretsViper.ReadInConfig()
+	if err := applyAuthContext(ctx); err != nil {
+		// Non-fatal: credentials are valid, context setup is best-effort.
+		log.Debug().Err(err).Msg("EnsureAuthenticated: applyAuthContext failed after lazy credential reload")
 	}
 	return nil
 }

--- a/internal/pkg/utils/login/login.go
+++ b/internal/pkg/utils/login/login.go
@@ -526,12 +526,16 @@ func applyAuthContext(ctx context.Context) error {
 		Id:   targetOrg.Id,
 	})
 
+	// Always write TargetProj so stale data from a previous session is never
+	// returned when the current org has no projects.
 	if len(projects) > 0 {
 		targetProj := projects[0]
 		state.TargetProj.Set(state.TargetProject{
 			Name: targetProj.Name,
 			Id:   targetProj.Id,
 		})
+	} else {
+		state.TargetProj.Set(state.TargetProject{})
 	}
 
 	return nil


### PR DESCRIPTION
## Problem
After previous changes to daemonize the login flow and improve overall I/O, there were still some rough edges when working with the CLI through an agent. Lack of consistent `--json` flag representation was still an issue for a few flags, primarily around not supporting a shorthand option. The `pc target` command also needed changes to better support "headless", or agentic operation effectively. In-client documentation around the specifics of some of these operations also need to be improved to better guide users and agents when authenticating.

## Solution
This PR improves the CLI's behavior in agentic/non-TTY contexts (Claude Code, Cursor, other AI coding agents). It builds on the daemon-backed login flow from #82

### `-j` shorthand added to login commands

`pc login` and `pc auth login` were missing the `-j` shorthand for `--json`, inconsistent with every other command. Fixed.

### Lazy auth completion

Added `login.EnsureAuthenticated`, called from a `PersistentPreRun` hook on the root command. After a successful browser login, the next command run — any command — automatically detects the completed session, reloads credentials, and initializes the target org/project context. A second `pc login --json` call is no longer required before running other commands.

Commands that don't require authentication are explicitly exempted: `pc login`, `pc logout`, `pc auth login/logout/configure/clear/status/_daemon`, `pc auth local-keys`/`list`, `pc target` (which handles its own auth after local-state early returns), `pc version`, and all `pc config` subcommands.

### `pc target` fixes

- **TTY auto-detection** — `pc target` now detects non-TTY stdout and enables JSON mode automatically, consistent with `pc login`.
- **No-flags JSON mode** — `pc target --json` with no targeting flags now returns the current target context as JSON (equivalent to `--show --json`) instead of an error. This early return is correctly placed before auth and API calls, so it works for API-key users and requires no credentials.
- **`--show` and `--clear` unblocked** — These are local-state-only operations; they now return before the auth gate and before any API calls.
- **Re-auth URL stays on stderr** — When `pc target` triggers an org-switch re-auth, the auth URL is printed to stderr only. Stdout remains a single JSON document, keeping output compatible with `jq .` and other single-document parsers.
- **Missing `return` after `exit.Error`** — Added `return` guards after all `exit.Error` calls in target and root pre-run, preventing fall-through when the exit handler is mocked in tests.

### `applyAuthContext` / `RunPostAuthSetup` refactor

Extracted the org/project state-setting logic from `RunPostAuthSetup` into a new `applyAuthContext` helper that returns the user's email. This eliminates a redundant `oauth.Token` + `ParseClaimsUnverified` call that `RunPostAuthSetup` was making immediately after `applyAuthContext` had already fetched the same data. `applyAuthContext` now also always writes `state.TargetProj` (clearing it when the org has no projects), preventing stale project data from a previous session from appearing in the authenticated JSON response.

### Root pre-run JSON error output

`EnsureAuthenticated` errors in the root `PersistentPreRun` now check both TTY state and the command's own `--json`/`-j` flag, so auth errors are machine-readable when a caller explicitly requests JSON even in a TTY context.

### Deduplication

Extracted `printTargetContextJSON()` in `target.go`, replacing three identical blocks that each read `state.GetTargetContext()`, masked the API key, and printed JSON.

### Documentation

Updated `pc login`, `pc auth login`, and `pc target` help text to document the interactive vs. agentic flows, the two-call pending/authenticated pattern, session resumability, and the lazy context initialization behavior. Also fixed a typo in `pc target`'s example (`-project` → `--project`).

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
  ### Interactive login (TTY)                                                                                                                                                                                                                                                                                                                                  
  - [ ] `pc login` opens a browser and completes auth, sets target org/project, prints success message
  - [ ] `pc auth login` same as above                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                               
  ### Agentic login (non-TTY / `--json`)                                                                                                                                                                                                                                                                                                                       
  - [ ] `pc login --json` returns `{"status":"pending","url":"...","session_id":"..."}` and exits immediately                                                                                                                                                                                                                                                  
  - [ ] `-j` shorthand works identically on both `pc login` and `pc auth login`                                                                                                                                                                                                                                                                                
  - [ ] Second `pc login --json` after completing browser auth returns `{"status":"authenticated",...}` with org/project populated                                                                                                                                                                                                                             
  - [ ] Running any other command (e.g. `pc index list --json`) after browser auth — without a second `pc login` call — succeeds and sets target context automatically                                                                                                                                                                                         
  - [ ] Piping output (`pc login | cat`) triggers non-TTY path automatically without needing `--json`                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                               
  ### Lazy auth / `EnsureAuthenticated`                                                                                                                                                                                                                                                                                                                        
  - [ ] After `pc login --json` + browser auth, `pc index list --json` works without a second login call                                                                                                                                                                                                                                                       
  - [ ] `pc auth status` works with no credentials (not blocked by auth gate)                                                                                                                                                                                                                                                                                  
  - [ ] `pc auth local-keys list` works with no credentials (not blocked by auth gate)                                                                                                                                                                                                                                                                         
  - [ ] `pc version` works with no credentials                                                                                                                                                                                                                                                                                                                 
  - [ ] All `pc config` subcommands work with no credentials                                                                                                                                                                                                                                                                                                   
                                                                     
  ### `pc target`                                                                                                                                                                                                                                                                                                                                              
  - [ ] `pc target --show` works with no credentials                 
  - [ ] `pc target --clear` works with no credentials                                                                                                                                                                                                                                                                                                          
  - [ ] `pc target --json` (no flags) returns current target context as JSON, works with no credentials
  - [ ] `pc target --json --org "name"` sets org and returns updated context as JSON                                                                                                                                                                                                                                                                           
  - [ ] `pc target --json --org "name" --project "name"` sets both and returns updated context                                                                                                                                                                                                                                                                 
  - [ ] `pc target` in a TTY launches interactive selector as before                                                                                                                                                                                                                                                                                           
  - [ ] `pc target` in a non-TTY (or with `--json`) without targeting flags returns current context rather than erroring                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                               
  ### Auth errors                                                                                                                                                                                                                                                                                                                                              
  - [ ] Running a command requiring auth with no credentials returns `{"error":"..."}` to stdout when stdout is non-TTY                                                                                                                                                                                                                                        
  - [ ] Running a command requiring auth with no credentials and `--json` flag returns `{"error":"..."}` to stdout even in a TTY                                                                                                                                                                                                                               
  - [ ] "authentication in progress" error includes the auth URL when daemon is still running 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a global authentication pre-check for most commands and changes login/target behavior in non-TTY JSON mode, which could affect automation and command execution paths if the skip list or auth detection is incorrect.
> 
> **Overview**
> **Adds a root-level auth gate for most commands.** `pc` now runs `login.EnsureAuthenticated()` in `PersistentPreRun`, with a curated skip list for commands that manage credentials/local state, and auto-detects JSON mode (non-TTY stdout or `--json/-j`) to format auth errors appropriately.
> 
> **Improves non-interactive/agentic UX.** `login` and `auth login` gain `-j` shorthand and updated help/examples; `target` now auto-enables JSON mode in non-TTY contexts, supports `pc target --json` as an auth-free “show current context” path, and centralizes JSON context printing.
> 
> **Refactors and extends post-auth setup.** Login utilities split context initialization into `applyAuthContext()`, ensure target project state is cleared when no projects exist, keep stdout clean during wait-mode by printing auth URLs to stderr, and introduce `EnsureAuthenticated()` to lazily complete pending daemon sessions and auto-initialize org/project context after successful browser auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb7ecd2c76455f773e572758469ba4db5c76224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->