### PR TITLE
Fix: empty --namespace coerced to __default__ on all vector/record commands

### DIFF
--- a/internal/pkg/cli/command/index/record/search.go
+++ b/internal/pkg/cli/command/index/record/search.go
@@ -111,7 +111,7 @@ func NewSearchCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to search")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to search")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to search")
 	cmd.Flags().IntVarP(&options.topK, "top-k", "k", defaultSearchTopK, "number of results to return")
 	cmd.Flags().Var(&options.inputs, "inputs", "query inputs for search (inline JSON, ./path.json, or '-' for stdin); requires integrated embedding")
 	cmd.Flags().Var(&options.filter, "filter", "metadata filter (inline JSON, ./path.json, or '-' for stdin)")

--- a/internal/pkg/cli/command/index/record/upsert.go
+++ b/internal/pkg/cli/command/index/record/upsert.go
@@ -75,7 +75,7 @@ func NewUpsertCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of index to upsert into")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to upsert into")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to upsert into")
 	cmd.Flags().StringVar(&options.file, "file", "", "request body JSON or JSONL (inline, ./path.json[l], or '-' for stdin; only one argument may use stdin)")
 	cmd.Flags().StringVar(&options.file, "body", "", "alias for --file")
 	cmd.Flags().IntVarP(&options.batchSize, "batch-size", "b", 96, "records per batch (max 96)")

--- a/internal/pkg/cli/command/index/vector/delete.go
+++ b/internal/pkg/cli/command/index/vector/delete.go
@@ -44,7 +44,7 @@ func NewDeleteVectorsCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to delete vectors from")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to delete vectors from")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to delete vectors from")
 	cmd.Flags().Var(&options.ids, "ids", "IDs of the vectors to delete (inline JSON string array, ./path.json, or '-' for stdin)")
 	cmd.Flags().Var(&options.filter, "filter", "filter to delete the vectors with (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().BoolVar(&options.deleteAllVectors, "all-vectors", false, "delete all vectors from the namespace")

--- a/internal/pkg/cli/command/index/vector/fetch.go
+++ b/internal/pkg/cli/command/index/vector/fetch.go
@@ -69,7 +69,7 @@ func NewFetchCmd() *cobra.Command {
 	cmd.Flags().VarP(&options.ids, "ids", "i", "IDs of vectors to fetch (inline JSON string array, ./path.json, or '-' for stdin)")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the fetch (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to fetch from")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to fetch from")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to fetch from")
 	cmd.Flags().Uint32VarP(&options.limit, "limit", "l", 0, "maximum number of vectors to fetch")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "pagination token to continue a previous listing operation")
 	cmd.Flags().StringVar(&options.body, "body", "", "request body JSON (inline, ./path.json, or '-' for stdin; only one argument may use stdin)")

--- a/internal/pkg/cli/command/index/vector/list_vectors.go
+++ b/internal/pkg/cli/command/index/vector/list_vectors.go
@@ -37,7 +37,7 @@ func NewListVectorsCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to list vectors from")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to list vectors from")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to list vectors from")
 	cmd.Flags().Uint32VarP(&options.limit, "limit", "l", 0, "maximum number of vectors to list")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "pagination token to continue a previous listing operation")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")

--- a/internal/pkg/cli/command/index/vector/query.go
+++ b/internal/pkg/cli/command/index/vector/query.go
@@ -82,7 +82,7 @@ func NewQueryCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to query")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "index namespace to query")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "index namespace to query")
 	cmd.Flags().Uint32VarP(&options.topK, "top-k", "k", 10, "maximum number of results to return")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the query (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().BoolVar(&options.includeValues, "include-values", false, "include vector values in the query results")

--- a/internal/pkg/cli/command/index/vector/update.go
+++ b/internal/pkg/cli/command/index/vector/update.go
@@ -71,7 +71,7 @@ func NewUpdateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to update")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to update the vector in")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to update the vector in")
 	cmd.Flags().StringVar(&options.id, "id", "", "ID of the vector to update")
 	cmd.Flags().Var(&options.values, "values", "values to update the vector with (inline JSON array, ./path.json, or '-' for stdin)")
 	cmd.Flags().Var(&options.sparseIndices, "sparse-indices", "sparse indices to update the vector with (inline JSON array, ./path.json, or '-' for stdin)")

--- a/internal/pkg/cli/command/index/vector/upsert.go
+++ b/internal/pkg/cli/command/index/vector/upsert.go
@@ -61,7 +61,7 @@ func NewUpsertCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of index to upsert into")
-	cmd.Flags().StringVar(&options.namespace, "namespace", "__default__", "namespace to upsert into")
+	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to upsert into")
 	cmd.Flags().StringVar(&options.file, "file", "", "request body JSON or JSONL (inline, ./path.json[l], or '-' for stdin; only one argument may use stdin)")
 	cmd.Flags().StringVar(&options.file, "body", "", "alias for --file")
 	cmd.Flags().IntVarP(&options.batchSize, "batch-size", "b", 500, "size of batches to upsert (default: 500)")

--- a/internal/pkg/utils/sdk/client.go
+++ b/internal/pkg/utils/sdk/client.go
@@ -170,7 +170,11 @@ func NewIndexConnection(ctx context.Context, pc *pinecone.Client, indexName stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index connection: %w", err)
 	}
-	return ic, nil
+	// The SDK coerces Namespace="" to "__default__" inside pc.Index. Re-apply
+	// the caller's value via WithNamespace so that an empty namespace is sent
+	// as "" on the wire (proto3 zero value) rather than the literal string
+	// "__default__", which requires an active server-side conversion.
+	return ic.WithNamespace(namespace), nil
 }
 
 func getCLIAPIKeyForProject(ctx context.Context, ac *pinecone.AdminClient, project *pinecone.Project) (string, error) {


### PR DESCRIPTION
## Problem

Fixes #85.

When a user passes `--namespace ""` to any index vector or record command, the CLI ignores it and silently queries the `__default__` namespace instead, returning no results even though vectors exist in the default namespace.

The root cause is in the Go SDK: `pc.Index()` coerces `Namespace: ""` to `"__default__"` unconditionally ([go-pinecone client.go:286](https://github.com/pinecone-io/go-pinecone/blob/main/pinecone/client.go)). This means the literal string `"__default__"` is sent on the wire over gRPC.

Sending `"__default__"` requires an active server-side conversion to map it back to `""` (the canonical internal representation of the default namespace). That conversion only runs at API version ≥ 2025-04; at older API versions the server actively blocks it with a validation error. By contrast, sending `""` directly passes through unchanged on every server version — it is the proto3 zero value for a string field (omitted on the wire) and the server always treats an absent namespace as the default.

Additionally, the Go SDK's assumption was incorrect: `"__default__"` was introduced as a human-readable **alias** that clients *can* send, not the canonical wire format. Clients should send `""` and let the server surface `"__default__"` in responses (which it does at ≥ 2025-04).

## Solution

Two changes:

1. **`sdk.NewIndexConnection`**: after `pc.Index()` creates the connection (where the `""` → `"__default__"` coercion happens), immediately re-apply the caller's original namespace via `ic.WithNamespace(namespace)`. `WithNamespace` sets the field directly, bypassing the coercion. Empty namespace now reaches the gRPC wire as `""` (proto3 zero value / omitted field), which the server correctly interprets as the default namespace on all versions.

2. **`--namespace` flag defaults**: changed from `"__default__"` to `""` across all eight affected commands (`index vector query/upsert/update/fetch/delete/list` and `index record upsert/search`). This makes the CLI default consistent with how the server represents the default namespace (e.g. as shown by `pc index stats`).

Note: the underlying Go SDK also needs a fix — the coercion at `pc.Index()` should be removed. The CLI workaround via `WithNamespace` is sufficient for now but the SDK fix should be tracked separately.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `just test-unit` passes with no failures.
- To validate end-to-end: run `pc index stats --index-name <index>` on an index with vectors in the default namespace (shows `""` key), then confirm `pc index vector query --index-name <index> --vector '[...]' --top-k 5 --json` returns matches (previously required explicit `--namespace __default__` which itself was broken for some users).