### PR TITLE
Add `pc index import` command group

### DIFF
--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -3,6 +3,7 @@ package index
 import (
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/index/backup"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/index/collection"
+	importcmd "github.com/pinecone-io/cli/internal/pkg/cli/command/index/import"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/index/namespace"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/index/record"
 	"github.com/pinecone-io/cli/internal/pkg/cli/command/index/restore"
@@ -56,6 +57,7 @@ func NewIndexCmd() *cobra.Command {
 	cmd.AddCommand(backup.NewBackupCmd())
 	cmd.AddCommand(restore.NewRestoreCmd())
 	cmd.AddCommand(collection.NewCollectionCmd())
+	cmd.AddCommand(importcmd.NewImportCmd())
 
 	return cmd
 }

--- a/internal/pkg/cli/command/index/import/cancel.go
+++ b/internal/pkg/cli/command/index/import/cancel.go
@@ -1,0 +1,82 @@
+package importcmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
+	"github.com/pinecone-io/cli/internal/pkg/utils/style"
+	"github.com/pinecone-io/cli/internal/pkg/utils/text"
+	"github.com/spf13/cobra"
+)
+
+type cancelImportCmdOptions struct {
+	indexName string
+	importId  string
+	json      bool
+}
+
+// NewCancelImportCmd returns the "import cancel" subcommand.
+func NewCancelImportCmd() *cobra.Command {
+	options := cancelImportCmdOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "cancel",
+		Short: "Cancel an in-progress import operation",
+		Long: help.Long(`
+			Cancel an import operation that is currently pending or in progress.
+			Already-completed or failed imports cannot be cancelled.
+		`),
+		Example: help.Examples(`
+			pc index import cancel --index-name my-index --id import-123
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			pc := sdk.NewPineconeClient(ctx)
+			ic, err := sdk.NewIndexConnection(ctx, pc, options.indexName, "")
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to connect to index: %s\n", err)
+				exit.Error(err, "Failed to connect to index")
+			}
+
+			err = runCancelImportCmd(ctx, ic, options)
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to cancel import: %s\n", err)
+				exit.Error(err, "Failed to cancel import")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index the import belongs to")
+	cmd.Flags().StringVarP(&options.importId, "id", "i", "", "ID of the import to cancel")
+	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
+	_ = cmd.MarkFlagRequired("index-name")
+	_ = cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func runCancelImportCmd(ctx context.Context, svc ImportService, options cancelImportCmdOptions) error {
+	if strings.TrimSpace(options.importId) == "" {
+		return fmt.Errorf("--id is required")
+	}
+
+	if err := svc.CancelImport(ctx, options.importId); err != nil {
+		return err
+	}
+
+	if options.json {
+		fmt.Println(text.IndentJSON(struct {
+			Cancelled bool   `json:"cancelled"`
+			Id        string `json:"id"`
+		}{Cancelled: true, Id: options.importId}))
+		return nil
+	}
+
+	msg.SuccessMsg("Import %s cancelled.\n", style.Emphasis(options.importId))
+	return nil
+}

--- a/internal/pkg/cli/command/index/import/cancel_test.go
+++ b/internal/pkg/cli/command/index/import/cancel_test.go
@@ -1,0 +1,55 @@
+package importcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pinecone-io/cli/internal/pkg/cli/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runCancelImportCmd_RequiresID(t *testing.T) {
+	svc := &mockImportService{}
+	opts := cancelImportCmdOptions{}
+
+	err := runCancelImportCmd(context.Background(), svc, opts)
+
+	assert.Error(t, err)
+	assert.Empty(t, svc.lastCancelImportId)
+}
+
+func Test_runCancelImportCmd_Succeeds(t *testing.T) {
+	svc := &mockImportService{}
+	opts := cancelImportCmdOptions{importId: "import-1"}
+
+	err := runCancelImportCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "import-1", svc.lastCancelImportId)
+	}
+}
+
+func Test_runCancelImportCmd_SucceedsJSON(t *testing.T) {
+	svc := &mockImportService{}
+	opts := cancelImportCmdOptions{importId: "import-1", json: true}
+
+	out := testutils.CaptureStdout(t, func() {
+		err := runCancelImportCmd(context.Background(), svc, opts)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"import-1"`)
+	assert.Contains(t, out, `"cancelled": true`)
+}
+
+func Test_runCancelImportCmd_PropagatesError(t *testing.T) {
+	svc := &mockImportService{
+		cancelImportErr: errors.New("cancel failed"),
+	}
+	opts := cancelImportCmdOptions{importId: "import-1"}
+
+	err := runCancelImportCmd(context.Background(), svc, opts)
+
+	assert.EqualError(t, err, "cancel failed")
+}

--- a/internal/pkg/cli/command/index/import/cmd.go
+++ b/internal/pkg/cli/command/index/import/cmd.go
@@ -1,0 +1,60 @@
+package importcmd
+
+import (
+	"context"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+	"github.com/spf13/cobra"
+)
+
+// ImportService abstracts the Pinecone IndexConnection for unit testing across import commands.
+type ImportService interface {
+	StartImport(ctx context.Context, uri string, integrationId *string, errorMode *string) (*pinecone.StartImportResponse, error)
+	DescribeImport(ctx context.Context, id string) (*pinecone.Import, error)
+	ListImports(ctx context.Context, limit *int32, paginationToken *string) (*pinecone.ListImportsResponse, error)
+	CancelImport(ctx context.Context, id string) error
+}
+
+var importHelp = help.Long(`
+	Manage imports for a serverless index. An import loads vector data from
+	a storage provider (S3, GCS, or Azure) directly into an index without requiring you to
+	push records through the upsert API. For secure data sources, you can configure a 
+	storage integration through the Pinecone console.
+
+	Use these commands to start, describe, list, and cancel import operations.
+
+	Docs:
+	  Import data:          https://docs.pinecone.io/guides/index-data/import-data
+	  Storage integrations: https://docs.pinecone.io/guides/operations/integrations/manage-storage-integrations
+`)
+
+// NewImportCmd returns the parent "import" command with all subcommands attached.
+func NewImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "import",
+		Short:   "Manage imports for a serverless index",
+		Long:    importHelp,
+		GroupID: help.GROUP_INDEX_MANAGEMENT.ID,
+		Example: help.Examples(`
+			# Start an import from an S3 URI
+			pc index import start --index-name my-index --uri s3://my-bucket/data/
+
+			# List imports for an index
+			pc index import list --index-name my-index
+
+			# Describe a specific import
+			pc index import describe --index-name my-index --id import-123
+
+			# Cancel an in-progress import
+			pc index import cancel --index-name my-index --id import-123
+		`),
+	}
+
+	cmd.AddCommand(NewStartImportCmd())
+	cmd.AddCommand(NewDescribeImportCmd())
+	cmd.AddCommand(NewListImportsCmd())
+	cmd.AddCommand(NewCancelImportCmd())
+
+	return cmd
+}

--- a/internal/pkg/cli/command/index/import/describe.go
+++ b/internal/pkg/cli/command/index/import/describe.go
@@ -1,0 +1,80 @@
+package importcmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
+	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
+	"github.com/pinecone-io/cli/internal/pkg/utils/text"
+	"github.com/spf13/cobra"
+)
+
+type describeImportCmdOptions struct {
+	indexName string
+	importId  string
+	json      bool
+}
+
+// NewDescribeImportCmd returns the "import describe" subcommand.
+func NewDescribeImportCmd() *cobra.Command {
+	options := describeImportCmdOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Describe an import operation by ID",
+		Long: help.Long(`
+			Show the current status and details of an import operation, including
+			percent complete, records imported, and any error messages.
+		`),
+		Example: help.Examples(`
+			pc index import describe --index-name my-index --id import-123
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			pc := sdk.NewPineconeClient(ctx)
+			ic, err := sdk.NewIndexConnection(ctx, pc, options.indexName, "")
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to connect to index: %s\n", err)
+				exit.Error(err, "Failed to connect to index")
+			}
+
+			err = runDescribeImportCmd(ctx, ic, options)
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to describe import: %s\n", err)
+				exit.Error(err, "Failed to describe import")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index the import belongs to")
+	cmd.Flags().StringVarP(&options.importId, "id", "i", "", "ID of the import to describe")
+	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
+	_ = cmd.MarkFlagRequired("index-name")
+	_ = cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func runDescribeImportCmd(ctx context.Context, svc ImportService, options describeImportCmdOptions) error {
+	if strings.TrimSpace(options.importId) == "" {
+		return fmt.Errorf("--id is required")
+	}
+
+	resp, err := svc.DescribeImport(ctx, options.importId)
+	if err != nil {
+		return err
+	}
+
+	if options.json {
+		fmt.Println(text.IndentJSON(resp))
+	} else {
+		presenters.PrintImportTable(resp)
+	}
+
+	return nil
+}

--- a/internal/pkg/cli/command/index/import/describe_test.go
+++ b/internal/pkg/cli/command/index/import/describe_test.go
@@ -1,0 +1,69 @@
+package importcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pinecone-io/cli/internal/pkg/cli/testutils"
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runDescribeImportCmd_RequiresID(t *testing.T) {
+	svc := &mockImportService{}
+	opts := describeImportCmdOptions{}
+
+	err := runDescribeImportCmd(context.Background(), svc, opts)
+
+	assert.Error(t, err)
+	assert.Empty(t, svc.lastDescribeImportId)
+}
+
+func Test_runDescribeImportCmd_Succeeds(t *testing.T) {
+	now := time.Now()
+	svc := &mockImportService{
+		describeImportResp: &pinecone.Import{
+			Id:        "import-1",
+			Status:    pinecone.InProgress,
+			Uri:       "s3://my-bucket/data/",
+			CreatedAt: &now,
+		},
+	}
+	opts := describeImportCmdOptions{importId: "import-1"}
+
+	err := runDescribeImportCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "import-1", svc.lastDescribeImportId)
+	}
+}
+
+func Test_runDescribeImportCmd_SucceedsJSON(t *testing.T) {
+	svc := &mockImportService{
+		describeImportResp: &pinecone.Import{
+			Id:     "import-1",
+			Status: pinecone.Completed,
+		},
+	}
+	opts := describeImportCmdOptions{importId: "import-1", json: true}
+
+	out := testutils.CaptureStdout(t, func() {
+		err := runDescribeImportCmd(context.Background(), svc, opts)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"import-1"`)
+}
+
+func Test_runDescribeImportCmd_PropagatesError(t *testing.T) {
+	svc := &mockImportService{
+		describeImportErr: errors.New("not found"),
+	}
+	opts := describeImportCmdOptions{importId: "import-1"}
+
+	err := runDescribeImportCmd(context.Background(), svc, opts)
+
+	assert.EqualError(t, err, "not found")
+}

--- a/internal/pkg/cli/command/index/import/import_test.go
+++ b/internal/pkg/cli/command/index/import/import_test.go
@@ -1,0 +1,49 @@
+package importcmd
+
+import (
+	"context"
+
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+)
+
+type mockImportService struct {
+	lastStartImportUri           string
+	lastStartImportIntegrationId *string
+	lastStartImportErrorMode     *string
+	lastDescribeImportId         string
+	lastListImportsLimit         *int32
+	lastListImportsPaginationToken *string
+	lastCancelImportId           string
+
+	startImportResp  *pinecone.StartImportResponse
+	describeImportResp *pinecone.Import
+	listImportsResp  *pinecone.ListImportsResponse
+
+	startImportErr   error
+	describeImportErr error
+	listImportsErr   error
+	cancelImportErr  error
+}
+
+func (m *mockImportService) StartImport(ctx context.Context, uri string, integrationId *string, errorMode *string) (*pinecone.StartImportResponse, error) {
+	m.lastStartImportUri = uri
+	m.lastStartImportIntegrationId = integrationId
+	m.lastStartImportErrorMode = errorMode
+	return m.startImportResp, m.startImportErr
+}
+
+func (m *mockImportService) DescribeImport(ctx context.Context, id string) (*pinecone.Import, error) {
+	m.lastDescribeImportId = id
+	return m.describeImportResp, m.describeImportErr
+}
+
+func (m *mockImportService) ListImports(ctx context.Context, limit *int32, paginationToken *string) (*pinecone.ListImportsResponse, error) {
+	m.lastListImportsLimit = limit
+	m.lastListImportsPaginationToken = paginationToken
+	return m.listImportsResp, m.listImportsErr
+}
+
+func (m *mockImportService) CancelImport(ctx context.Context, id string) error {
+	m.lastCancelImportId = id
+	return m.cancelImportErr
+}

--- a/internal/pkg/cli/command/index/import/list.go
+++ b/internal/pkg/cli/command/index/import/list.go
@@ -1,0 +1,93 @@
+package importcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
+	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
+	"github.com/pinecone-io/cli/internal/pkg/utils/text"
+	"github.com/spf13/cobra"
+)
+
+type listImportsCmdOptions struct {
+	indexName       string
+	limit           int
+	paginationToken string
+	json            bool
+}
+
+// NewListImportsCmd returns the "import list" subcommand.
+func NewListImportsCmd() *cobra.Command {
+	options := listImportsCmdOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List import operations for an index",
+		Long: help.Long(`
+			List bulk import operations for the given index, with optional pagination.
+		`),
+		Example: help.Examples(`
+			# List all imports for an index
+			pc index import list --index-name my-index
+
+			# List imports with a page size limit
+			pc index import list --index-name my-index --limit 10
+
+			# Continue paginating from a previous call
+			pc index import list --index-name my-index --pagination-token <token>
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			pc := sdk.NewPineconeClient(ctx)
+			ic, err := sdk.NewIndexConnection(ctx, pc, options.indexName, "")
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to connect to index: %s\n", err)
+				exit.Error(err, "Failed to connect to index")
+			}
+
+			err = runListImportsCmd(ctx, ic, options)
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to list imports: %s\n", err)
+				exit.Error(err, "Failed to list imports")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index to list imports for")
+	cmd.Flags().IntVarP(&options.limit, "limit", "l", 0, "Maximum number of imports to return")
+	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "Pagination token to continue a previous listing operation")
+	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
+	_ = cmd.MarkFlagRequired("index-name")
+
+	return cmd
+}
+
+func runListImportsCmd(ctx context.Context, svc ImportService, options listImportsCmdOptions) error {
+	var limit *int32
+	if options.limit > 0 {
+		l := int32(options.limit)
+		limit = &l
+	}
+
+	var paginationToken *string
+	if options.paginationToken != "" {
+		paginationToken = &options.paginationToken
+	}
+
+	resp, err := svc.ListImports(ctx, limit, paginationToken)
+	if err != nil {
+		return err
+	}
+
+	if options.json {
+		fmt.Println(text.IndentJSON(resp))
+	} else {
+		presenters.PrintImportList(resp)
+	}
+
+	return nil
+}

--- a/internal/pkg/cli/command/index/import/list_test.go
+++ b/internal/pkg/cli/command/index/import/list_test.go
@@ -1,0 +1,72 @@
+package importcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pinecone-io/cli/internal/pkg/cli/testutils"
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runListImportsCmd_PopulatesParams(t *testing.T) {
+	svc := &mockImportService{
+		listImportsResp: &pinecone.ListImportsResponse{},
+	}
+	opts := listImportsCmdOptions{
+		limit:           5,
+		paginationToken: "next-page",
+	}
+
+	err := runListImportsCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		if assert.NotNil(t, svc.lastListImportsLimit) {
+			assert.Equal(t, int32(5), *svc.lastListImportsLimit)
+		}
+		if assert.NotNil(t, svc.lastListImportsPaginationToken) {
+			assert.Equal(t, "next-page", *svc.lastListImportsPaginationToken)
+		}
+	}
+}
+
+func Test_runListImportsCmd_OmitsZeroLimit(t *testing.T) {
+	svc := &mockImportService{
+		listImportsResp: &pinecone.ListImportsResponse{},
+	}
+	opts := listImportsCmdOptions{limit: 0}
+
+	err := runListImportsCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		assert.Nil(t, svc.lastListImportsLimit)
+	}
+}
+
+func Test_runListImportsCmd_SucceedsJSON(t *testing.T) {
+	svc := &mockImportService{
+		listImportsResp: &pinecone.ListImportsResponse{
+			Imports: []*pinecone.Import{{Id: "import-1"}},
+		},
+	}
+	opts := listImportsCmdOptions{json: true}
+
+	out := testutils.CaptureStdout(t, func() {
+		err := runListImportsCmd(context.Background(), svc, opts)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"import-1"`)
+}
+
+func Test_runListImportsCmd_PropagatesError(t *testing.T) {
+	svc := &mockImportService{
+		listImportsErr: errors.New("list failed"),
+	}
+	opts := listImportsCmdOptions{}
+
+	err := runListImportsCmd(context.Background(), svc, opts)
+
+	assert.EqualError(t, err, "list failed")
+}

--- a/internal/pkg/cli/command/index/import/start.go
+++ b/internal/pkg/cli/command/index/import/start.go
@@ -1,0 +1,113 @@
+package importcmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/exit"
+	"github.com/pinecone-io/cli/internal/pkg/utils/help"
+	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/presenters"
+	"github.com/pinecone-io/cli/internal/pkg/utils/sdk"
+	"github.com/pinecone-io/cli/internal/pkg/utils/style"
+	"github.com/pinecone-io/cli/internal/pkg/utils/text"
+	"github.com/spf13/cobra"
+)
+
+type startImportCmdOptions struct {
+	indexName     string
+	uri           string
+	integrationId string
+	errorMode     string
+	json          bool
+}
+
+// NewStartImportCmd returns the "import start" subcommand.
+func NewStartImportCmd() *cobra.Command {
+	options := startImportCmdOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start an import from a storage URI",
+		Long: help.Long(`
+			Start an import that loads vector data from a storage provider into a
+			serverless index. The URI must begin with the scheme of a supported provider
+			(e.g. "s3://").
+
+			For private buckets, configure a storage integration in the Pinecone console
+			and pass the integration ID with --integration-id.
+
+			Use --error-mode to control behavior when records fail: "continue" skips
+			failing records and keeps going; "abort" stops the import on first error.
+			Defaults to "continue".
+		`),
+		Example: help.Examples(`
+			# Start an import from a public S3 bucket
+			pc index import start --index-name my-index --uri s3://my-bucket/data/
+
+			# Start an import from a private bucket using a storage integration
+			pc index import start --index-name my-index --uri s3://my-bucket/data/ --integration-id intg-123
+
+			# Abort on the first error instead of continuing
+			pc index import start --index-name my-index --uri s3://my-bucket/data/ --error-mode abort
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			pc := sdk.NewPineconeClient(ctx)
+			ic, err := sdk.NewIndexConnection(ctx, pc, options.indexName, "")
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to connect to index: %s\n", err)
+				exit.Error(err, "Failed to connect to index")
+			}
+
+			err = runStartImportCmd(ctx, ic, options)
+			if err != nil {
+				msg.FailJSON(options.json, "Failed to start import: %s\n", err)
+				exit.Error(err, "Failed to start import")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index to import into")
+	cmd.Flags().StringVarP(&options.uri, "uri", "u", "", "URI of the data to import (e.g. s3://bucket/path/)")
+	cmd.Flags().StringVar(&options.integrationId, "integration-id", "", "Storage integration ID for private buckets")
+	cmd.Flags().StringVar(&options.errorMode, "error-mode", "", "How to handle record errors: continue (default) or abort")
+	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
+	_ = cmd.MarkFlagRequired("index-name")
+	_ = cmd.MarkFlagRequired("uri")
+
+	return cmd
+}
+
+func runStartImportCmd(ctx context.Context, svc ImportService, options startImportCmdOptions) error {
+	if strings.TrimSpace(options.uri) == "" {
+		return fmt.Errorf("--uri is required")
+	}
+
+	var integrationId *string
+	if options.integrationId != "" {
+		id := options.integrationId
+		integrationId = &id
+	}
+
+	var errorMode *string
+	if options.errorMode != "" {
+		em := options.errorMode
+		errorMode = &em
+	}
+
+	resp, err := svc.StartImport(ctx, options.uri, integrationId, errorMode)
+	if err != nil {
+		return err
+	}
+
+	if options.json {
+		fmt.Println(text.IndentJSON(resp))
+	} else {
+		msg.SuccessMsg("Import %s started.\n", style.Emphasis(resp.Id))
+		presenters.PrintStartImportTable(resp)
+	}
+
+	return nil
+}

--- a/internal/pkg/cli/command/index/import/start_test.go
+++ b/internal/pkg/cli/command/index/import/start_test.go
@@ -1,0 +1,87 @@
+package importcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pinecone-io/cli/internal/pkg/cli/testutils"
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runStartImportCmd_RequiresURI(t *testing.T) {
+	svc := &mockImportService{}
+	opts := startImportCmdOptions{}
+
+	err := runStartImportCmd(context.Background(), svc, opts)
+
+	assert.ErrorContains(t, err, "--uri is required")
+}
+
+func Test_runStartImportCmd_Succeeds(t *testing.T) {
+	svc := &mockImportService{
+		startImportResp: &pinecone.StartImportResponse{Id: "import-1"},
+	}
+	opts := startImportCmdOptions{
+		uri: "s3://my-bucket/data/",
+	}
+
+	err := runStartImportCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "s3://my-bucket/data/", svc.lastStartImportUri)
+	}
+}
+
+func Test_runStartImportCmd_PassesOptionalFields(t *testing.T) {
+	svc := &mockImportService{
+		startImportResp: &pinecone.StartImportResponse{Id: "import-1"},
+	}
+	opts := startImportCmdOptions{
+		uri:           "s3://my-bucket/data/",
+		integrationId: "intg-123",
+		errorMode:     "abort",
+	}
+
+	err := runStartImportCmd(context.Background(), svc, opts)
+
+	if assert.NoError(t, err) {
+		if assert.NotNil(t, svc.lastStartImportIntegrationId) {
+			assert.Equal(t, "intg-123", *svc.lastStartImportIntegrationId)
+		}
+		if assert.NotNil(t, svc.lastStartImportErrorMode) {
+			assert.Equal(t, "abort", *svc.lastStartImportErrorMode)
+		}
+		assert.Equal(t, "s3://my-bucket/data/", svc.lastStartImportUri)
+
+	}
+}
+
+func Test_runStartImportCmd_SucceedsJSON(t *testing.T) {
+	svc := &mockImportService{
+		startImportResp: &pinecone.StartImportResponse{Id: "import-1"},
+	}
+	opts := startImportCmdOptions{
+		uri:  "s3://my-bucket/data/",
+		json: true,
+	}
+
+	out := testutils.CaptureStdout(t, func() {
+		err := runStartImportCmd(context.Background(), svc, opts)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"import-1"`)
+}
+
+func Test_runStartImportCmd_PropagatesError(t *testing.T) {
+	svc := &mockImportService{
+		startImportErr: errors.New("start failed"),
+	}
+	opts := startImportCmdOptions{uri: "s3://my-bucket/data/"}
+
+	err := runStartImportCmd(context.Background(), svc, opts)
+
+	assert.EqualError(t, err, "start failed")
+}

--- a/internal/pkg/utils/presenters/backup.go
+++ b/internal/pkg/utils/presenters/backup.go
@@ -46,37 +46,42 @@ func PrintBackupTable(backup *pinecone.Backup) {
 }
 
 func PrintBackupList(list *pinecone.BackupList) {
-	writer := NewTabWriter()
 	if list == nil || len(list.Data) == 0 {
-		PrintEmptyState(writer, "backups")
+		w := NewTabWriter()
+		PrintEmptyState(w, "backups")
 		return
 	}
 
-	columns := []string{"BACKUP ID", "NAME", "INDEX", "STATUS", "CLOUD/REGION", "RECORDS", "NAMESPACES", "SIZE (B)", "CREATED"}
-	header := strings.Join(columns, "\t") + "\n"
-	fmt.Fprint(writer, header)
-
-	for _, b := range list.Data {
-		cloudRegion := fmt.Sprintf("%s/%s", b.Cloud, b.Region)
-		created := DisplayOrNone(b.CreatedAt)
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+	cols := []tableColumn{
+		{header: "BACKUP ID"},
+		{header: "NAME"},
+		{header: "INDEX"},
+		{header: "STATUS", colorizer: colorizeBackupStatus},
+		{header: "CLOUD/REGION"},
+		{header: "RECORDS"},
+		{header: "NAMESPACES"},
+		{header: "SIZE (B)"},
+		{header: "CREATED"},
+	}
+	rows := make([][]string, len(list.Data))
+	for i, b := range list.Data {
+		rows[i] = []string{
 			b.BackupId,
 			DisplayOrNone(b.Name),
 			b.SourceIndexName,
 			b.Status,
-			cloudRegion,
+			fmt.Sprintf("%s/%s", b.Cloud, b.Region),
 			DisplayOrNone(b.RecordCount),
 			DisplayOrNone(b.NamespaceCount),
 			DisplayOrNone(b.SizeBytes),
-			created,
-		)
+			DisplayOrNone(b.CreatedAt),
+		}
 	}
+	printColorizedTable(cols, rows)
 
 	if list.Pagination != nil && list.Pagination.Next != "" {
-		fmt.Fprintf(writer, "\nNext Pagination Token: %s\n", list.Pagination.Next)
+		fmt.Printf("\nNext Pagination Token: %s\n", list.Pagination.Next)
 	}
-
-	writer.Flush()
 }
 
 func PrintRestoreJob(job *pinecone.RestoreJob) {
@@ -102,18 +107,24 @@ func PrintRestoreJob(job *pinecone.RestoreJob) {
 }
 
 func PrintRestoreJobList(list *pinecone.RestoreJobList) {
-	writer := NewTabWriter()
 	if list == nil || len(list.Data) == 0 {
-		PrintEmptyState(writer, "restore jobs")
+		w := NewTabWriter()
+		PrintEmptyState(w, "restore jobs")
 		return
 	}
 
-	columns := []string{"RESTORE JOB ID", "BACKUP ID", "TARGET INDEX", "STATUS", "PERCENT", "CREATED", "COMPLETED"}
-	header := strings.Join(columns, "\t") + "\n"
-	fmt.Fprint(writer, header)
-
-	for _, job := range list.Data {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+	cols := []tableColumn{
+		{header: "RESTORE JOB ID"},
+		{header: "BACKUP ID"},
+		{header: "TARGET INDEX"},
+		{header: "STATUS", colorizer: colorizeRestoreJobStatus},
+		{header: "PERCENT"},
+		{header: "CREATED"},
+		{header: "COMPLETED"},
+	}
+	rows := make([][]string, len(list.Data))
+	for i, job := range list.Data {
+		rows[i] = []string{
 			job.RestoreJobId,
 			job.BackupId,
 			job.TargetIndexName,
@@ -121,14 +132,13 @@ func PrintRestoreJobList(list *pinecone.RestoreJobList) {
 			DisplayOrNone(job.PercentComplete),
 			formatTime(job.CreatedAt),
 			formatTimePtr(job.CompletedAt),
-		)
+		}
 	}
+	printColorizedTable(cols, rows)
 
 	if list.Pagination != nil && list.Pagination.Next != "" {
-		fmt.Fprintf(writer, "\nNext Pagination Token: %s\n", list.Pagination.Next)
+		fmt.Printf("\nNext Pagination Token: %s\n", list.Pagination.Next)
 	}
-
-	writer.Flush()
 }
 
 func colorizeBackupStatus(status string) string {

--- a/internal/pkg/utils/presenters/backup.go
+++ b/internal/pkg/utils/presenters/backup.go
@@ -33,7 +33,6 @@ func PrintBackupTable(backup *pinecone.Backup) {
 	fmt.Fprintf(writer, "Record Count\t%s\n", DisplayOrNone(backup.RecordCount))
 	fmt.Fprintf(writer, "Namespace Count\t%s\n", DisplayOrNone(backup.NamespaceCount))
 	fmt.Fprintf(writer, "Size (bytes)\t%s\n", DisplayOrNone(backup.SizeBytes))
-	fmt.Fprintf(writer, "Metric\t%s\n", DisplayOrNone(backup.Metric))
 	schema := "<none>"
 	if backup.Schema != nil {
 		schema = text.InlineJSON(backup.Schema)

--- a/internal/pkg/utils/presenters/import.go
+++ b/internal/pkg/utils/presenters/import.go
@@ -35,7 +35,7 @@ func PrintImportTable(imp *pinecone.Import) {
 	fmt.Fprint(writer, strings.Join(columns, "\t")+"\n")
 
 	fmt.Fprintf(writer, "Import ID\t%s\n", imp.Id)
-	fmt.Fprintf(writer, "Status\t%s\n", colorizeImportStatus(imp.Status))
+	fmt.Fprintf(writer, "Status\t%s\n", colorizeImportStatus(string(imp.Status)))
 	fmt.Fprintf(writer, "URI\t%s\n", imp.Uri)
 	fmt.Fprintf(writer, "Percent Complete\t%.1f%%\n", imp.PercentComplete)
 	fmt.Fprintf(writer, "Records Imported\t%d\n", imp.RecordsImported)
@@ -48,43 +48,49 @@ func PrintImportTable(imp *pinecone.Import) {
 
 // PrintImportList prints a table of import operations.
 func PrintImportList(list *pinecone.ListImportsResponse) {
-	writer := NewTabWriter()
 	if list == nil || len(list.Imports) == 0 {
-		PrintEmptyState(writer, "imports")
+		w := NewTabWriter()
+		PrintEmptyState(w, "imports")
 		return
 	}
 
-	columns := []string{"IMPORT ID", "STATUS", "URI", "PERCENT", "RECORDS", "CREATED", "FINISHED"}
-	fmt.Fprint(writer, strings.Join(columns, "\t")+"\n")
-
-	for _, imp := range list.Imports {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%.1f%%\t%d\t%s\t%s\n",
+	cols := []tableColumn{
+		{header: "IMPORT ID"},
+		{header: "STATUS", colorizer: colorizeImportStatus},
+		{header: "URI"},
+		{header: "PERCENT"},
+		{header: "RECORDS"},
+		{header: "CREATED"},
+		{header: "FINISHED"},
+	}
+	rows := make([][]string, len(list.Imports))
+	for i, imp := range list.Imports {
+		rows[i] = []string{
 			imp.Id,
-			colorizeImportStatus(imp.Status),
+			string(imp.Status),
 			imp.Uri,
-			imp.PercentComplete,
-			imp.RecordsImported,
+			fmt.Sprintf("%.1f%%", imp.PercentComplete),
+			fmt.Sprintf("%d", imp.RecordsImported),
 			formatTimePtr(imp.CreatedAt),
 			formatTimePtr(imp.FinishedAt),
-		)
+		}
 	}
+	printColorizedTable(cols, rows)
 
 	if list.NextPaginationToken != nil && *list.NextPaginationToken != "" {
-		fmt.Fprintf(writer, "\nNext Pagination Token: %s\n", *list.NextPaginationToken)
+		fmt.Printf("\nNext Pagination Token: %s\n", *list.NextPaginationToken)
 	}
-
-	writer.Flush()
 }
 
-func colorizeImportStatus(status pinecone.ImportStatus) string {
-	switch status {
+func colorizeImportStatus(status string) string {
+	switch pinecone.ImportStatus(status) {
 	case pinecone.Completed:
-		return style.StatusGreen(string(status))
+		return style.StatusGreen(status)
 	case pinecone.InProgress, pinecone.Pending:
-		return style.StatusYellow(string(status))
+		return style.StatusYellow(status)
 	case pinecone.Failed, pinecone.Cancelled:
-		return style.StatusRed(string(status))
+		return style.StatusRed(status)
 	default:
-		return string(status)
+		return status
 	}
 }

--- a/internal/pkg/utils/presenters/import.go
+++ b/internal/pkg/utils/presenters/import.go
@@ -1,0 +1,90 @@
+package presenters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pinecone-io/cli/internal/pkg/utils/style"
+	"github.com/pinecone-io/go-pinecone/v5/pinecone"
+)
+
+// PrintStartImportTable prints a summary of a newly started import operation.
+func PrintStartImportTable(resp *pinecone.StartImportResponse) {
+	writer := NewTabWriter()
+	if resp == nil {
+		PrintEmptyState(writer, "import details")
+		return
+	}
+
+	columns := []string{"ATTRIBUTE", "VALUE"}
+	fmt.Fprint(writer, strings.Join(columns, "\t")+"\n")
+	fmt.Fprintf(writer, "Import ID\t%s\n", resp.Id)
+
+	writer.Flush()
+}
+
+// PrintImportTable prints the full details of a single import operation.
+func PrintImportTable(imp *pinecone.Import) {
+	writer := NewTabWriter()
+	if imp == nil {
+		PrintEmptyState(writer, "import details")
+		return
+	}
+
+	columns := []string{"ATTRIBUTE", "VALUE"}
+	fmt.Fprint(writer, strings.Join(columns, "\t")+"\n")
+
+	fmt.Fprintf(writer, "Import ID\t%s\n", imp.Id)
+	fmt.Fprintf(writer, "Status\t%s\n", colorizeImportStatus(imp.Status))
+	fmt.Fprintf(writer, "URI\t%s\n", imp.Uri)
+	fmt.Fprintf(writer, "Percent Complete\t%.1f%%\n", imp.PercentComplete)
+	fmt.Fprintf(writer, "Records Imported\t%d\n", imp.RecordsImported)
+	fmt.Fprintf(writer, "Created At\t%s\n", formatTimePtr(imp.CreatedAt))
+	fmt.Fprintf(writer, "Finished At\t%s\n", formatTimePtr(imp.FinishedAt))
+	fmt.Fprintf(writer, "Error\t%s\n", DisplayOrNone(imp.Error))
+
+	writer.Flush()
+}
+
+// PrintImportList prints a table of import operations.
+func PrintImportList(list *pinecone.ListImportsResponse) {
+	writer := NewTabWriter()
+	if list == nil || len(list.Imports) == 0 {
+		PrintEmptyState(writer, "imports")
+		return
+	}
+
+	columns := []string{"IMPORT ID", "STATUS", "URI", "PERCENT", "RECORDS", "CREATED", "FINISHED"}
+	fmt.Fprint(writer, strings.Join(columns, "\t")+"\n")
+
+	for _, imp := range list.Imports {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%.1f%%\t%d\t%s\t%s\n",
+			imp.Id,
+			colorizeImportStatus(imp.Status),
+			imp.Uri,
+			imp.PercentComplete,
+			imp.RecordsImported,
+			formatTimePtr(imp.CreatedAt),
+			formatTimePtr(imp.FinishedAt),
+		)
+	}
+
+	if list.NextPaginationToken != nil && *list.NextPaginationToken != "" {
+		fmt.Fprintf(writer, "\nNext Pagination Token: %s\n", *list.NextPaginationToken)
+	}
+
+	writer.Flush()
+}
+
+func colorizeImportStatus(status pinecone.ImportStatus) string {
+	switch status {
+	case pinecone.Completed:
+		return style.StatusGreen(string(status))
+	case pinecone.InProgress, pinecone.Pending:
+		return style.StatusYellow(string(status))
+	case pinecone.Failed, pinecone.Cancelled:
+		return style.StatusRed(string(status))
+	default:
+		return string(status)
+	}
+}

--- a/internal/pkg/utils/presenters/tabwriter.go
+++ b/internal/pkg/utils/presenters/tabwriter.go
@@ -1,13 +1,75 @@
 package presenters
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 )
 
 func NewTabWriter() *tabwriter.Writer {
 	return tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
+}
+
+// tableColumn describes a single column in a printColorizedTable call.
+type tableColumn struct {
+	header    string
+	colorizer func(string) string // nil = no colorization
+}
+
+// printColorizedTable renders a tab-aligned table to stdout. Rows contain plain
+// string values; each column's optional colorizer is applied after tabwriter has
+// computed column widths, so ANSI bytes never affect alignment.
+// Columns are processed right-to-left so an earlier substitution never shifts
+// the byte offsets of columns already replaced in the same line.
+func printColorizedTable(cols []tableColumn, rows [][]string) {
+	headers := make([]string, len(cols))
+	for i, c := range cols {
+		headers[i] = c.header
+	}
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 12, 1, 3, ' ', 0)
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	for _, row := range rows {
+		fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+	w.Flush()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	fmt.Println(lines[0])
+
+	// Locate each column's byte offset in the formatted header line.
+	offsets := make([]int, len(cols))
+	cursor := 0
+	for i, h := range headers {
+		pos := strings.Index(lines[0][cursor:], h)
+		if pos < 0 {
+			continue
+		}
+		offsets[i] = cursor + pos
+		cursor = offsets[i] + len(h)
+	}
+
+	for i, row := range rows {
+		line := lines[i+1]
+		for j := len(cols) - 1; j >= 0; j-- {
+			if cols[j].colorizer == nil {
+				continue
+			}
+			plain := row[j]
+			colored := cols[j].colorizer(plain)
+			if colored == plain {
+				continue
+			}
+			start := offsets[j]
+			if start+len(plain) <= len(line) {
+				line = line[:start] + colored + line[start+len(plain):]
+			}
+		}
+		fmt.Println(line)
+	}
 }
 
 // PrintEmptyState prints a consistent placeholder for nil presenter inputs.


### PR DESCRIPTION
## Problem

The CLI has no support for bulk imports despite the Go SDK fully exposing them. Imports load vector data from a storage provider (S3, GCS, Azure) directly into a serverless index — a common data-loading path that currently requires dropping down to the API or SDK.

## Solution

Adds `pc index import` as a new subcommand group under `pc index`, alongside the existing `backup`, `restore`, and `collection` groups. Implements four subcommands backed by `IndexConnection.{StartImport, DescribeImport, ListImports, CancelImport}`.

Fixes a tabwriter column alignment bug where ANSI color codes in status cells inflated column widths, causing headers to misalign with data rows in list views. Introduces `printColorizedTable`, which buffers plain text through tabwriter for correct width calculation, then splices colorized values in at the byte offsets read from the formatted header line. Applies to import, backup, and restore job list tables.

## Commands

**Start an import**
```
$ pc index import start --index-name my-index --uri s3://my-bucket/data/
[SUCCESS] Import import-abc123 started.

ATTRIBUTE   VALUE
Import ID   import-abc123
```

Optional flags: `--error-mode continue|abort` (default: `continue`), `--integration-id` for private buckets.

**List imports for an index**
```
$ pc index import list --index-name my-index
IMPORT ID       STATUS      URI                       PERCENT   RECORDS   CREATED               FINISHED
import-abc123   InProgress  s3://my-bucket/data/      42.0%     18302     2026-06-05T18:00:00Z  <none>
import-def456   Completed   s3://my-bucket/archive/   100.0%    84011     2026-06-04T09:00:00Z  2026-06-04T09:12:00Z
```

**Describe a specific import**
```
$ pc index import describe --index-name my-index --id import-abc123
ATTRIBUTE          VALUE
Import ID          import-abc123
Status             InProgress
URI                s3://my-bucket/data/
Percent Complete   42.0%
Records Imported   18302
Created At         2026-06-05T18:00:00Z
Finished At        <none>
Error              <none>
```

**Cancel an in-progress import**
```
$ pc index import cancel --index-name my-index --id import-abc123
[SUCCESS] Import import-abc123 cancelled.
```

All commands support `--json` for machine-readable output.

## Notes

- Imports operate on an `IndexConnection` (requires the index host), unlike `backup`/`restore` which are client-level operations. Each command resolves the host via `sdk.NewIndexConnection`.
- `ImportService` interface is satisfied directly by `*pinecone.IndexConnection` — no adapter needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New index data-loading operations can trigger large imports and cancel in-flight jobs; changes are mostly CLI/presentation with unit tests, but mistakes could affect production index data loads.
> 
> **Overview**
> Adds **`pc index import`** under index management so users can **start**, **describe**, **list**, and **cancel** serverless bulk imports from storage URIs (with optional `--integration-id`, `--error-mode`, pagination, and `--json`). Commands use an index connection via `sdk.NewIndexConnection` and a testable `ImportService` backed by the Go SDK.
> 
> Introduces **`printColorizedTable`** so list tables can colorize status without breaking tab alignment; **backup** and **restore job** list output is switched to this helper, and new import list/detail presenters use it. Backup detail view drops the **Metric** row from the attribute table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf60fab152b4883e314c224de6a698c4c77bf3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->