### PR TITLE
Normalize `--index-name` flag and shorthand conventions

### DIFF
--- a/internal/pkg/cli/command/index/backup/create.go
+++ b/internal/pkg/cli/command/index/backup/create.go
@@ -61,7 +61,7 @@ func NewCreateBackupCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of the index to back up")
 	cmd.Flags().StringVarP(&options.description, "description", "d", "", "Optional description for the backup")
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "Optional name for the backup")
+	cmd.Flags().StringVar(&options.name, "name", "", "Optional name for the backup")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
 	_ = cmd.MarkFlagRequired("index-name")
 

--- a/internal/pkg/cli/command/index/cmd.go
+++ b/internal/pkg/cli/command/index/cmd.go
@@ -33,8 +33,8 @@ func NewIndexCmd() *cobra.Command {
 		Example: help.Examples(`
 			pc index list
 			pc index create --name my-index --dimension 1536 --metric cosine --cloud aws --region us-east-1
-			pc index describe --name my-index
-			pc index delete --name my-index
+			pc index describe --index-name my-index
+			pc index delete --index-name my-index
 		`),
 		GroupID: help.GROUP_VECTORDB.ID,
 	}

--- a/internal/pkg/cli/command/index/configure.go
+++ b/internal/pkg/cli/command/index/configure.go
@@ -18,7 +18,7 @@ import (
 
 type configureIndexOptions struct {
 	// required for index lookup
-	name string
+	indexName string
 
 	// pods
 	podType  string
@@ -50,16 +50,23 @@ func NewConfigureIndexCmd() *cobra.Command {
 		Use:   "configure",
 		Short: "Configure an existing index",
 		Example: help.Examples(`
-			pc index configure --name "index-name" --deletion-protection "enabled"
+			pc index configure --index-name "index-name" --deletion-protection "enabled"
 		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("index-name") && !cmd.Flags().Changed("name") {
+				return fmt.Errorf("required flag(s) \"index-name\" not set")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runConfigureIndexCmd(cmd.Context(), cmd, options)
 		},
 	}
 
 	// Required flags
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "Name of index to configure")
-	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of index to configure")
+	cmd.Flags().StringVarP(&options.indexName, "name", "n", "", "Name of index to configure")
+	_ = cmd.Flags().MarkDeprecated("name", "use --index-name instead")
 
 	// pods
 	cmd.Flags().StringVarP(&options.podType, "pod-type", "t", "", "Type of pod to use, can only upgrade when configuring")
@@ -119,11 +126,11 @@ func runConfigureIndexCmd(ctx context.Context, cmd *cobra.Command, options confi
 	// read capacity configuration
 	readCapacity, err := buildReadCapacityFromFlags(cmd, options.readMode, options.readNodeType, options.readShards, options.readReplicas)
 	if err != nil {
-		msg.FailJSON(options.json, "Failed to configure index %s: %+v\n", style.Emphasis(options.name), err)
+		msg.FailJSON(options.json, "Failed to configure index %s: %+v\n", style.Emphasis(options.indexName), err)
 		exit.Error(err, "Failed to configure index")
 	}
 
-	idx, err := pc.ConfigureIndex(ctx, options.name, pinecone.ConfigureIndexParams{
+	idx, err := pc.ConfigureIndex(ctx, options.indexName, pinecone.ConfigureIndexParams{
 		PodType:            options.podType,
 		Replicas:           options.replicas,
 		DeletionProtection: pinecone.DeletionProtection(options.deletionProtection),
@@ -132,7 +139,7 @@ func runConfigureIndexCmd(ctx context.Context, cmd *cobra.Command, options confi
 		Embed:              embed,
 	})
 	if err != nil {
-		msg.FailJSON(options.json, "Failed to configure index %s: %+v\n", style.Emphasis(options.name), err)
+		msg.FailJSON(options.json, "Failed to configure index %s: %+v\n", style.Emphasis(options.indexName), err)
 		exit.Error(err, "Failed to configure index")
 	}
 
@@ -142,7 +149,7 @@ func runConfigureIndexCmd(ctx context.Context, cmd *cobra.Command, options confi
 		return
 	}
 
-	describeCommand := fmt.Sprintf("pc index describe --name %s", idx.Name)
+	describeCommand := fmt.Sprintf("pc index describe --index-name %s", idx.Name)
 	msg.SuccessMsg("Index %s configured successfully. Run %s to check status. \n\n", style.Emphasis(idx.Name), style.Code(describeCommand))
 	presenters.PrintDescribeIndexTable(idx)
 }

--- a/internal/pkg/cli/command/index/create.go
+++ b/internal/pkg/cli/command/index/create.go
@@ -325,7 +325,7 @@ func renderSuccessOutput(idx *pinecone.Index, options createIndexOptions) {
 		return
 	}
 
-	describeCommand := fmt.Sprintf("pc index describe --name %s", idx.Name)
+	describeCommand := fmt.Sprintf("pc index describe --index-name %s", idx.Name)
 	msg.SuccessMsg("Index %s created successfully. Run %s to check status. \n\n", style.Emphasis(idx.Name), style.Code(describeCommand))
 	presenters.PrintDescribeIndexTable(idx)
 }

--- a/internal/pkg/cli/command/index/delete.go
+++ b/internal/pkg/cli/command/index/delete.go
@@ -15,8 +15,8 @@ import (
 )
 
 type deleteCmdOptions struct {
-	name string
-	json bool
+	indexName string
+	json      bool
 }
 
 // DeleteIndexService abstracts the Pinecone Go SDK for unit testing (runDeleteIndexCmd)
@@ -31,8 +31,14 @@ func NewDeleteCmd() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete an index by name",
 		Example: help.Examples(`
-			pc index delete --name "index-name"
+			pc index delete --index-name "index-name"
 		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("index-name") && !cmd.Flags().Changed("name") {
+				return fmt.Errorf("required flag(s) \"index-name\" not set")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			pc := sdk.NewPineconeClient(ctx)
@@ -40,26 +46,27 @@ func NewDeleteCmd() *cobra.Command {
 			err := runDeleteIndexCmd(ctx, pc, options)
 			if err != nil {
 				if strings.Contains(err.Error(), "not found") {
-					msg.FailJSON(options.json, "The index %s does not exist\n", style.Emphasis(options.name))
-					exit.Errorf(err, "The index %s does not exist", style.Emphasis(options.name))
+					msg.FailJSON(options.json, "The index %s does not exist\n", style.Emphasis(options.indexName))
+					exit.Errorf(err, "The index %s does not exist", style.Emphasis(options.indexName))
 				} else {
-					msg.FailJSON(options.json, "Failed to delete index %s: %s\n", style.Emphasis(options.name), err)
-					exit.Errorf(err, "Failed to delete index %s", style.Emphasis(options.name))
+					msg.FailJSON(options.json, "Failed to delete index %s: %s\n", style.Emphasis(options.indexName), err)
+					exit.Errorf(err, "Failed to delete index %s", style.Emphasis(options.indexName))
 				}
 			}
 		},
 	}
 
 	// required flags
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to delete")
-	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of index to delete")
+	cmd.Flags().StringVarP(&options.indexName, "name", "n", "", "name of index to delete")
+	_ = cmd.Flags().MarkDeprecated("name", "use --index-name instead")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output result as JSON")
 
 	return cmd
 }
 
 func runDeleteIndexCmd(ctx context.Context, svc DeleteIndexService, options deleteCmdOptions) error {
-	if err := svc.DeleteIndex(ctx, options.name); err != nil {
+	if err := svc.DeleteIndex(ctx, options.indexName); err != nil {
 		return err
 	}
 
@@ -67,10 +74,10 @@ func runDeleteIndexCmd(ctx context.Context, svc DeleteIndexService, options dele
 		fmt.Println(text.IndentJSON(struct {
 			Deleted bool   `json:"deleted"`
 			Name    string `json:"name"`
-		}{Deleted: true, Name: options.name}))
+		}{Deleted: true, Name: options.indexName}))
 		return nil
 	}
 
-	msg.SuccessMsg("Index %s deleted.\n", style.Emphasis(options.name))
+	msg.SuccessMsg("Index %s deleted.\n", style.Emphasis(options.indexName))
 	return nil
 }

--- a/internal/pkg/cli/command/index/delete_test.go
+++ b/internal/pkg/cli/command/index/delete_test.go
@@ -21,7 +21,7 @@ func (m *mockDeleteIndexService) DeleteIndex(ctx context.Context, name string) e
 
 func Test_runDeleteIndexCmd_Succeeds(t *testing.T) {
 	svc := &mockDeleteIndexService{}
-	opts := deleteCmdOptions{name: "my-index"}
+	opts := deleteCmdOptions{indexName: "my-index"}
 
 	err := runDeleteIndexCmd(context.Background(), svc, opts)
 
@@ -31,7 +31,7 @@ func Test_runDeleteIndexCmd_Succeeds(t *testing.T) {
 
 func Test_runDeleteIndexCmd_SucceedsJSON(t *testing.T) {
 	svc := &mockDeleteIndexService{}
-	opts := deleteCmdOptions{name: "my-index", json: true}
+	opts := deleteCmdOptions{indexName: "my-index", json: true}
 
 	out := testutils.CaptureStdout(t, func() {
 		err := runDeleteIndexCmd(context.Background(), svc, opts)
@@ -43,7 +43,7 @@ func Test_runDeleteIndexCmd_SucceedsJSON(t *testing.T) {
 
 func Test_runDeleteIndexCmd_PropagatesError(t *testing.T) {
 	svc := &mockDeleteIndexService{deleteErr: errors.New("not found")}
-	opts := deleteCmdOptions{name: "missing"}
+	opts := deleteCmdOptions{indexName: "missing"}
 
 	err := runDeleteIndexCmd(context.Background(), svc, opts)
 

--- a/internal/pkg/cli/command/index/describe.go
+++ b/internal/pkg/cli/command/index/describe.go
@@ -16,8 +16,8 @@ import (
 )
 
 type describeCmdOptions struct {
-	name string
-	json bool
+	indexName string
+	json      bool
 }
 
 func NewDescribeCmd() *cobra.Command {
@@ -27,20 +27,26 @@ func NewDescribeCmd() *cobra.Command {
 		Use:   "describe",
 		Short: "Describe an index by name",
 		Example: help.Examples(`
-			pc index describe --name "index-name"
+			pc index describe --index-name "index-name"
 		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("index-name") && !cmd.Flags().Changed("name") {
+				return fmt.Errorf("required flag(s) \"index-name\" not set")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			pc := sdk.NewPineconeClient(ctx)
 
-			idx, err := pc.DescribeIndex(cmd.Context(), options.name)
+			idx, err := pc.DescribeIndex(cmd.Context(), options.indexName)
 			if err != nil {
 				if strings.Contains(err.Error(), "not found") {
-					msg.FailJSON(options.json, "The index %s does not exist\n", style.Emphasis(options.name))
-					exit.Errorf(err, "The index %s does not exist", style.Emphasis(options.name))
+					msg.FailJSON(options.json, "The index %s does not exist\n", style.Emphasis(options.indexName))
+					exit.Errorf(err, "The index %s does not exist", style.Emphasis(options.indexName))
 				} else {
-					msg.FailJSON(options.json, "Failed to describe index %s: %s\n", style.Emphasis(options.name), err)
-					exit.Errorf(err, "Failed to describe index %s", style.Emphasis(options.name))
+					msg.FailJSON(options.json, "Failed to describe index %s: %s\n", style.Emphasis(options.indexName), err)
+					exit.Errorf(err, "Failed to describe index %s", style.Emphasis(options.indexName))
 				}
 			}
 
@@ -54,8 +60,9 @@ func NewDescribeCmd() *cobra.Command {
 	}
 
 	// required flags
-	cmd.Flags().StringVarP(&options.name, "name", "n", "", "name of index to describe")
-	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of index to describe")
+	cmd.Flags().StringVarP(&options.indexName, "name", "n", "", "name of index to describe")
+	_ = cmd.Flags().MarkDeprecated("name", "use --index-name instead")
 
 	// optional flags
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")

--- a/internal/pkg/cli/command/index/describe_stats.go
+++ b/internal/pkg/cli/command/index/describe_stats.go
@@ -43,7 +43,7 @@ func NewDescribeIndexStatsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of index to describe stats for")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of index to describe stats for")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the operation (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")
 	_ = cmd.MarkFlagRequired("index-name")

--- a/internal/pkg/cli/command/index/import/cancel.go
+++ b/internal/pkg/cli/command/index/import/cancel.go
@@ -51,8 +51,8 @@ func NewCancelImportCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index the import belongs to")
-	cmd.Flags().StringVarP(&options.importId, "id", "i", "", "ID of the import to cancel")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of the index the import belongs to")
+	cmd.Flags().StringVar(&options.importId, "id", "", "ID of the import to cancel")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
 	_ = cmd.MarkFlagRequired("index-name")
 	_ = cmd.MarkFlagRequired("id")

--- a/internal/pkg/cli/command/index/import/describe.go
+++ b/internal/pkg/cli/command/index/import/describe.go
@@ -51,8 +51,8 @@ func NewDescribeImportCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index the import belongs to")
-	cmd.Flags().StringVarP(&options.importId, "id", "i", "", "ID of the import to describe")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of the index the import belongs to")
+	cmd.Flags().StringVar(&options.importId, "id", "", "ID of the import to describe")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")
 	_ = cmd.MarkFlagRequired("index-name")
 	_ = cmd.MarkFlagRequired("id")

--- a/internal/pkg/cli/command/index/import/list.go
+++ b/internal/pkg/cli/command/index/import/list.go
@@ -57,7 +57,7 @@ func NewListImportsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index to list imports for")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of the index to list imports for")
 	cmd.Flags().IntVarP(&options.limit, "limit", "l", 0, "Maximum number of imports to return")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "Pagination token to continue a previous listing operation")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "Output as JSON")

--- a/internal/pkg/cli/command/index/import/start.go
+++ b/internal/pkg/cli/command/index/import/start.go
@@ -69,7 +69,7 @@ func NewStartImportCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "Name of the index to import into")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "Name of the index to import into")
 	cmd.Flags().StringVarP(&options.uri, "uri", "u", "", "URI of the data to import (e.g. s3://bucket/path/)")
 	cmd.Flags().StringVar(&options.integrationId, "integration-id", "", "Storage integration ID for private buckets")
 	cmd.Flags().StringVar(&options.errorMode, "error-mode", "", "How to handle record errors: continue (default) or abort")

--- a/internal/pkg/cli/command/index/namespace/create.go
+++ b/internal/pkg/cli/command/index/namespace/create.go
@@ -72,7 +72,7 @@ func NewCreateNamespaceCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to create the namespace in")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to create the namespace in")
 	cmd.Flags().StringVar(&options.name, "name", "", "name of the namespace to create")
 	cmd.Flags().StringSliceVar(&options.metadataSchema, "schema", []string{}, "metadata schema for the namespace")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")

--- a/internal/pkg/cli/command/index/namespace/delete.go
+++ b/internal/pkg/cli/command/index/namespace/delete.go
@@ -58,7 +58,7 @@ func NewDeleteNamespaceCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to delete the namespace from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to delete the namespace from")
 	cmd.Flags().StringVar(&options.name, "name", "", "name of the namespace to delete")
 	_ = cmd.MarkFlagRequired("index-name")
 	_ = cmd.MarkFlagRequired("name")

--- a/internal/pkg/cli/command/index/namespace/describe.go
+++ b/internal/pkg/cli/command/index/namespace/describe.go
@@ -60,7 +60,7 @@ func NewDescribeNamespaceCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to describe the namespace from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to describe the namespace from")
 	cmd.Flags().StringVar(&options.name, "name", "", "name of the namespace to describe")
 	cmd.Flags().BoolVarP(&options.json, "json", "j", false, "output as JSON")
 	_ = cmd.MarkFlagRequired("index-name")

--- a/internal/pkg/cli/command/index/namespace/list.go
+++ b/internal/pkg/cli/command/index/namespace/list.go
@@ -70,7 +70,7 @@ func NewListNamespaceCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to list namespaces from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to list namespaces from")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "pagination token to continue a previous listing operation")
 	cmd.Flags().Uint32VarP(&options.limit, "limit", "l", 0, "maximum number of namespaces to list")
 	cmd.Flags().StringVar(&options.prefix, "prefix", "", "prefix to filter namespaces by")

--- a/internal/pkg/cli/command/index/record/search.go
+++ b/internal/pkg/cli/command/index/record/search.go
@@ -110,7 +110,7 @@ func NewSearchCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to search")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to search")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to search")
 	cmd.Flags().IntVarP(&options.topK, "top-k", "k", defaultSearchTopK, "number of results to return")
 	cmd.Flags().Var(&options.inputs, "inputs", "query inputs for search (inline JSON, ./path.json, or '-' for stdin); requires integrated embedding")

--- a/internal/pkg/cli/command/index/record/upsert.go
+++ b/internal/pkg/cli/command/index/record/upsert.go
@@ -74,7 +74,7 @@ func NewUpsertCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of index to upsert into")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of index to upsert into")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to upsert into")
 	cmd.Flags().StringVar(&options.file, "file", "", "request body JSON or JSONL (inline, ./path.json[l], or '-' for stdin; only one argument may use stdin)")
 	cmd.Flags().StringVar(&options.file, "body", "", "alias for --file")

--- a/internal/pkg/cli/command/index/vector/delete.go
+++ b/internal/pkg/cli/command/index/vector/delete.go
@@ -43,7 +43,7 @@ func NewDeleteVectorsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to delete vectors from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to delete vectors from")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to delete vectors from")
 	cmd.Flags().Var(&options.ids, "ids", "IDs of the vectors to delete (inline JSON string array, ./path.json, or '-' for stdin)")
 	cmd.Flags().Var(&options.filter, "filter", "filter to delete the vectors with (inline JSON, ./path.json, or '-' for stdin)")

--- a/internal/pkg/cli/command/index/vector/fetch.go
+++ b/internal/pkg/cli/command/index/vector/fetch.go
@@ -66,7 +66,7 @@ func NewFetchCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().VarP(&options.ids, "ids", "i", "IDs of vectors to fetch (inline JSON string array, ./path.json, or '-' for stdin)")
+	cmd.Flags().Var(&options.ids, "ids", "IDs of vectors to fetch (inline JSON string array, ./path.json, or '-' for stdin)")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the fetch (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to fetch from")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to fetch from")

--- a/internal/pkg/cli/command/index/vector/fetch.go
+++ b/internal/pkg/cli/command/index/vector/fetch.go
@@ -68,7 +68,7 @@ func NewFetchCmd() *cobra.Command {
 
 	cmd.Flags().VarP(&options.ids, "ids", "i", "IDs of vectors to fetch (inline JSON string array, ./path.json, or '-' for stdin)")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the fetch (inline JSON, ./path.json, or '-' for stdin)")
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to fetch from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to fetch from")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to fetch from")
 	cmd.Flags().Uint32VarP(&options.limit, "limit", "l", 0, "maximum number of vectors to fetch")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "pagination token to continue a previous listing operation")

--- a/internal/pkg/cli/command/index/vector/list_vectors.go
+++ b/internal/pkg/cli/command/index/vector/list_vectors.go
@@ -36,7 +36,7 @@ func NewListVectorsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to list vectors from")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to list vectors from")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to list vectors from")
 	cmd.Flags().Uint32VarP(&options.limit, "limit", "l", 0, "maximum number of vectors to list")
 	cmd.Flags().StringVarP(&options.paginationToken, "pagination-token", "p", "", "pagination token to continue a previous listing operation")

--- a/internal/pkg/cli/command/index/vector/query.go
+++ b/internal/pkg/cli/command/index/vector/query.go
@@ -81,13 +81,13 @@ func NewQueryCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to query")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to query")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "index namespace to query")
 	cmd.Flags().Uint32VarP(&options.topK, "top-k", "k", 10, "maximum number of results to return")
 	cmd.Flags().VarP(&options.filter, "filter", "f", "metadata filter to apply to the query (inline JSON, ./path.json, or '-' for stdin)")
 	cmd.Flags().BoolVar(&options.includeValues, "include-values", false, "include vector values in the query results")
 	cmd.Flags().BoolVar(&options.includeMetadata, "include-metadata", false, "include metadata in the query results")
-	cmd.Flags().StringVarP(&options.id, "id", "i", "", "ID of the vector to query against")
+	cmd.Flags().StringVar(&options.id, "id", "", "ID of the vector to query against")
 	cmd.Flags().VarP(&options.vector, "vector", "v", "vector values to query against (inline JSON array, ./path.json, or '-' for stdin)")
 	cmd.Flags().Var(&options.sparseIndices, "sparse-indices", "sparse indices to query against (inline JSON array, ./path.json, or '-' for stdin)")
 	cmd.Flags().Var(&options.sparseValues, "sparse-values", "sparse values to query against (inline JSON array, ./path.json, or '-' for stdin)")

--- a/internal/pkg/cli/command/index/vector/update.go
+++ b/internal/pkg/cli/command/index/vector/update.go
@@ -70,7 +70,7 @@ func NewUpdateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of the index to update")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of the index to update")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to update the vector in")
 	cmd.Flags().StringVar(&options.id, "id", "", "ID of the vector to update")
 	cmd.Flags().Var(&options.values, "values", "values to update the vector with (inline JSON array, ./path.json, or '-' for stdin)")

--- a/internal/pkg/cli/command/index/vector/upsert.go
+++ b/internal/pkg/cli/command/index/vector/upsert.go
@@ -60,7 +60,7 @@ func NewUpsertCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.indexName, "index-name", "n", "", "name of index to upsert into")
+	cmd.Flags().StringVarP(&options.indexName, "index-name", "i", "", "name of index to upsert into")
 	cmd.Flags().StringVar(&options.namespace, "namespace", "", "namespace to upsert into")
 	cmd.Flags().StringVar(&options.file, "file", "", "request body JSON or JSONL (inline, ./path.json[l], or '-' for stdin; only one argument may use stdin)")
 	cmd.Flags().StringVar(&options.file, "body", "", "alias for --file")

--- a/test/e2e/helpers/wait.go
+++ b/test/e2e/helpers/wait.go
@@ -43,7 +43,7 @@ func WaitForIndexReady(c JSONRunner, name string, max time.Duration) error {
 				State string `json:"state"`
 			} `json:"status"`
 		}
-		stdout, err := c.RunJSON(&idx, "index", "describe", "--name", name)
+		stdout, err := c.RunJSON(&idx, "index", "describe", "--index-name", name)
 		if err != nil {
 			// If index not found yet, keep polling
 			if strings.Contains(stdout, "does not exist") {

--- a/test/e2e/index_serverless_test.go
+++ b/test/e2e/index_serverless_test.go
@@ -8,7 +8,7 @@ import (
 
 func (s *ServiceAccountSuite) TestIndexServerless_ServiceAccountDescribeAndList() {
 	var desc pinecone.Index
-	_, err := s.cli.RunJSONCtx(s.ctx, &desc, "index", "describe", "--name", s.indexName)
+	_, err := s.cli.RunJSONCtx(s.ctx, &desc, "index", "describe", "--index-name", s.indexName)
 	s.Require().NoError(err, "index describe failed")
 	s.Require().Equal(s.indexName, desc.Name, "describe name mismatch")
 
@@ -33,7 +33,7 @@ func (a *APIKeySuite) TestIndexServerless_APIKeyDescribeAndList() {
 	}
 
 	var desc pinecone.Index
-	_, err := a.cli.RunJSONCtx(a.ctx, &desc, "index", "describe", "--name", a.indexName)
+	_, err := a.cli.RunJSONCtx(a.ctx, &desc, "index", "describe", "--index-name", a.indexName)
 	a.Require().NoError(err, "index describe failed (api key)")
 	a.Require().Equal(a.indexName, desc.Name, "describe name mismatch (api key)")
 

--- a/test/e2e/suite_api_test.go
+++ b/test/e2e/suite_api_test.go
@@ -72,7 +72,7 @@ func (a *APIKeySuite) SetupSuite() {
 
 func (a *APIKeySuite) TearDownSuite() {
 	if a.createdIndex && a.indexName != "" && a.cli != nil {
-		_, _, _ = a.cli.RunCtx(a.ctx, "index", "delete", "--name", a.indexName)
+		_, _, _ = a.cli.RunCtx(a.ctx, "index", "delete", "--index-name", a.indexName)
 	}
 	if a.tempHome != "" {
 		_ = os.RemoveAll(a.tempHome)

--- a/test/e2e/suite_sa_test.go
+++ b/test/e2e/suite_sa_test.go
@@ -57,6 +57,6 @@ func (s *ServiceAccountSuite) TearDownSuite() {
 	if !s.createdIdx || s.indexName == "" || s.cli == nil {
 		return
 	}
-	_, _, err := s.cli.RunCtx(s.ctx, "index", "delete", "--name", s.indexName)
+	_, _, err := s.cli.RunCtx(s.ctx, "index", "delete", "--index-name", s.indexName)
 	s.Require().NoError(err, "index delete failed (sa)")
 }


### PR DESCRIPTION
## Problem

The CLI had two different flag names for the same concept depending on context. Core index lifecycle commands (`describe`, `delete`, `configure`) used `--name` to identify the index, while every other command that operated on an index (vector ops, imports, namespaces, backups, stats) used `--index-name`. This meant users had to remember which \"mode\" they were in, and made scripting inconsistent.

A secondary issue: `--index-name` had `-n` as its shorthand on most commands, which doesn't correspond to the first letter of either word in the flag name and conflicted with the mental model that `-n` = `--name`.

## Solution

Introduce a clear semantic split enforced uniformly across all index subcommands:

- **`--index-name` (-i)** — always refers to an existing index being operated on
- **`--name` (-n)** — always names a resource being created or labeled (new index, backup name, namespace name, etc.)

### Changes by group

**`index describe`, `index delete`, `index configure`** (breaking for these three):
- Primary flag renamed from `--name` to `--index-name` with shorthand `-i`
- `--name` / `-n` kept as a deprecated alias via `MarkDeprecated` — prints a warning but continues to work, validated via `PreRunE` so either flag satisfies the required check
- Example strings and post-success hints updated to use `--index-name`

**All other `--index-name` commands** (stats, vector/\*, record/\*, import/\*, namespace/\*, backup/\*):
- Shorthand changed from `-n` to `-i` to match the new convention

**`--id` on `vector query`, `import cancel`, `import describe`**:
- Shorthand `-i` removed to free it up for `--index-name`; these flags take UUIDs that are always pasted, not typed, so the shorthand had no ergonomic value, alongside being 2 fewer characters than the full flag.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Plan

- `just test-unit` passes
- Manually verify deprecated alias: `pc index describe --name <idx>` should print a deprecation warning and still return results
- Manually verify new flag: `pc index describe --index-name <idx>` and `pc index describe -i <idx>` work as expected
- e2e suite updated to use `--index-name` on all describe/delete calls