### PR TITLE
V1 Finalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guide for AI agents and assistants contributing to this repository.
 
 ## Project overview
 
-`pc` is the official Pinecone CLI — open source, public preview.
+`pc` is the official Pinecone CLI — open source.
 
 - **Entry point:** `cmd/pc/main.go` → `cliRootCmd.Execute()` (package `internal/pkg/cli/command/root`)
 - **Module:** `github.com/pinecone-io/cli`
@@ -43,8 +43,17 @@ Four root groups (defined in `internal/pkg/cli/command/root/root.go`):
 |---|---|
 | **Auth** | auth, login, logout, target, whoami |
 | **Admin** | organization, project, apiKey |
-| **VectorDB** | index, collection, backup |
+| **VectorDB** | index |
 | **Misc** | version, config |
+
+`pc index` itself has internal subgroups:
+
+| Subgroup | Subcommands |
+|---|---|
+| _(top-level index ops)_ | describe, list, create, configure, delete, describe-stats |
+| **Data** | record, vector |
+| **Namespace** | namespace |
+| **Index Management** | backup, restore, collection, import |
 
 ### Presenter system
 
@@ -67,6 +76,8 @@ Credentials and tokens are stored in `~/.config/pinecone/`. The directory holds 
 - `config.yaml` — non-secret settings (`color`, `environment`)
 - `secrets.yaml` — credentials and tokens (`api_key`, `client_id`, `client_secret`, `oauth2_token`); created with `0600` permissions
 
+The `pc config` command manages these settings via a key-based interface. Valid keys: `api-key`, `color`, `environment`. Core subcommands: `get <key>`, `set <key> <value>`, `unset <key>`, `list`, `describe <key>`. Legacy shorthand commands (`set-api-key`, `set-color`, `set-environment`, `get-api-key`) still exist but the key-based interface is canonical.
+
 ### Input handling
 
 `internal/pkg/utils/argio/` unifies three JSON input methods:
@@ -83,6 +94,107 @@ Available on most commands. Forces structured, machine-readable output. Also act
 
 ---
 
+## Patterns for writing commands
+
+### Output: messages, styling, and exits
+
+Never call `fmt.Print*` or `os.Exit` directly. Use the dedicated packages:
+
+| Package | Use for |
+|---|---|
+| `internal/pkg/utils/msg/` | User-facing messages to stderr: `msg.SuccessMsg`, `msg.WarnMsg`, `msg.InfoMsg`, `msg.FailMsg`, `msg.FailJSON` |
+| `internal/pkg/utils/style/` | Inline styled text: `style.Code()`, `style.URL()`, `style.Emphasis()`, `style.Spinner()` |
+| `internal/pkg/utils/exit/` | Process exits: `exit.Success()`, `exit.Error()`, `exit.ErrorMsg()` |
+| `internal/pkg/utils/text/` | JSON marshaling: `text.InlineJSON()`, `text.IndentJSON()` (never `json.Marshal` directly — it HTML-escapes) |
+
+`msg.FailJSON(isJSON, ...)` writes an error to stderr in the right format (plain or JSON) based on whether `--json` is active. Always use it when a command can fail in JSON mode.
+
+`style.*` functions respect the user's `color` setting and TTY state — never use raw ANSI codes or `lipgloss` directly in command handlers.
+
+### Help text
+
+Use `help.Long()` and `help.Examples()` to write multiline help strings. Both functions accept heredocs and normalize indentation:
+
+```go
+Long: help.Long(`
+    Brief description here.
+
+    More detail on second paragraph.
+`),
+Example: help.Examples(`
+    pc index create --name my-index --dimension 1536
+    pc index create --name my-index --help
+`),
+```
+
+`help.Examples()` automatically prepends `$` to each command line and indents the block. Use the predefined group constants (`help.GROUP_AUTH`, `help.GROUP_VECTORDB`, `help.GROUP_INDEX_DATA`, etc.) when registering subcommand groups with `cmd.AddGroup()`.
+
+### Custom flag types for JSON input
+
+For flags that accept JSON arrays or objects, use the typed flag wrappers in `internal/pkg/utils/flags/` instead of plain string flags. They automatically support inline JSON, file paths, and stdin (`-`):
+
+| Type | Use for |
+|---|---|
+| `flags.JSONObject` | A JSON object (`{...}`) |
+| `flags.Float32List` | JSON array of float32 |
+| `flags.Int32List` | JSON array of int32 |
+| `flags.UInt32List` | JSON array of uint32 |
+| `flags.StringList` | JSON array of strings |
+
+Register with `cmd.Flags().Var(&myFlag, "flag-name", "description")`.
+
+### Command testability: narrow service interfaces
+
+Commands should not depend on the full SDK client directly. Define a narrow interface for the operations the command needs, and accept it as a parameter:
+
+```go
+type CreateIndexService interface {
+    CreateIndex(ctx context.Context, req *pinecone.CreateIndexRequest) (*pinecone.Index, error)
+}
+
+func RunCreateIndex(ctx context.Context, svc CreateIndexService, opts CreateIndexOptions) error { ... }
+```
+
+This lets unit tests pass a mock without spinning up a real Pinecone client. See `internal/pkg/cli/command/index/create.go` for a reference implementation.
+
+### Target org and project
+
+Commands that operate on project-scoped resources must resolve the target org and project at runtime. Use:
+
+```go
+import "github.com/pinecone-io/cli/internal/pkg/utils/configuration/state"
+
+orgId, err := state.GetTargetOrgId()
+projectId, err := state.GetTargetProjectId()
+```
+
+Both return an error if no target has been set (e.g., user hasn't run `pc target`). Surface the error through `exit.Error` so the user gets a clear prompt to run `pc target`.
+
+### Logging
+
+Use `internal/pkg/utils/log/` for internal diagnostics. Output goes to stderr and is gated by `PINECONE_LOG_LEVEL`:
+
+```go
+log.Debug(ctx).Str("index", name).Msg("fetching index")
+log.Info(ctx).Msg("authenticated")
+```
+
+Never use `log/` for user-facing messages — that's `msg/`'s job.
+
+---
+
+## Notable environment variables
+
+| Variable | Effect |
+|---|---|
+| `PINECONE_API_KEY` | Overrides stored API key (highest-priority auth) |
+| `PINECONE_CLIENT_ID` / `PINECONE_CLIENT_SECRET` | Service account credentials |
+| `PINECONE_ENVIRONMENT` | Target environment: `production` (default) or `staging` |
+| `PINECONE_LOG_LEVEL` | Enable diagnostic logging: `INFO`, `DEBUG`, or `TRACE` |
+| `PINECONE_CLI_MAX_JSON_BYTES` | Override the JSON input size limit (default 1 GiB) |
+
+---
+
 ## Key directories
 
 | Path | Purpose |
@@ -90,6 +202,7 @@ Available on most commands. Forces structured, machine-readable output. Also act
 | `cmd/pc/` | Entry point |
 | `internal/pkg/cli/command/` | All command implementations, organized by domain (`index/`, `auth/`, `project/`, etc.) |
 | `internal/pkg/utils/` | Shared utilities: presenters, sdk, oauth, argio, flags, configuration, etc. |
+| `scripts/` | Shell helpers: `install.sh`, `uninstall.sh` |
 | `test/e2e/` | End-to-end integration tests |
 
 ---

--- a/README.md
+++ b/README.md
@@ -178,26 +178,43 @@ Use a project API key directly. Provides access to control/data plane operations
 pc auth configure --api-key "YOUR_API_KEY"
 
 # alternatively
-pc config set-api-key "YOUR_API_KEY"
+pc config set api-key "YOUR_API_KEY"
 ```
 
 For more detailed information, see the [CLI authentication](https://docs.pinecone.io/reference/cli/authentication) documentation.
 
 ## Data plane commands overview
 
-Work with your vector data inside an index. These commands require `--index-name` and optionally `--namespace`:
+Work with data inside an index. Most commands require `--index-name` and optionally `--namespace`:
 
-- Ingest and manage records:
+- Dense and sparse vectors (pre-vectorized data):
   - `pc index vector upsert` — insert or update vectors from JSON/JSONL
   - `pc index vector list` — list vectors (with pagination)
   - `pc index vector fetch` — fetch by IDs or metadata filter
   - `pc index vector update` — update a vector by ID or update many via metadata filter
   - `pc index vector delete` — delete by IDs, by filter, or delete all in a namespace
   - `pc index vector query` — nearest-neighbor search by values or vector ID
+- Text records (integrated indexes with built-in vectorization):
+  - `pc index record upsert` — upsert text records from JSON/JSONL
+  - `pc index record search` — search records by text or vector
+- Namespace management:
+  - `pc index namespace list/describe/create/delete`
 - Index statistics:
   - `pc index stats` — show dimension, vector counts, namespace summary, and metadata field counts (optionally filtered)
 
-Tip: add `--json` to many commands to get structured output.
+Note: add `--json` to many commands to get structured output.
+
+## Index management commands
+
+Manage the lifecycle of indexes and their data:
+
+- Backups and restore jobs (serverless indexes):
+  - `pc index backup create/list/describe/delete` — create and manage index backups
+  - `pc index restore list/describe` — view and monitor restore jobs
+- Bulk imports (serverless indexes):
+  - `pc index import start/list/describe/cancel` — import data into an index from an external source
+- Collections (pod-based indexes):
+  - `pc index collection create/list/describe/delete` — create static snapshots of pod-based indexes
 
 ## Quickstart
 
@@ -208,7 +225,7 @@ After installing the CLI, authenticate with user login or set an API key, verify
 pc auth login
 
 # Option 2: Set API key directly
-pc config set-api-key "YOUR_API_KEY"
+pc config set api-key "YOUR_API_KEY"
 
 # Verify authentication
 pc auth whoami
@@ -223,7 +240,7 @@ pc index list
 
 ## Working with data
 
-Once you've created an index you can use `pc index upsert` to begin storing data in Pinecone. There are a variety of ways to get your data into Pinecone through the CLI.
+Once you've created an index you can use `pc index vector upsert` to begin storing data in Pinecone. There are a variety of ways to get your data into Pinecone through the CLI.
 
 ### JSON input formats
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 `pc` is Pinecone on the command line.
 
-> ⚠️ **Note:** This CLI is in [public preview](https://docs.pinecone.io/assistant-release-notes/feature-availability) and does not yet support all features available through the Pinecone API. Please try it out and let us know of any feedback. You'll want to upgrade often as we address feedback and add additional features.
-
 ## Installation
 
 ### Homebrew (macOS, Linux)

--- a/internal/pkg/utils/inputpolicy/input_policy.go
+++ b/internal/pkg/utils/inputpolicy/input_policy.go
@@ -15,7 +15,7 @@ const (
 
 var (
 	// Limits can be overridden via env vars at process start.
-	MaxBodyJSONBytes int64 = parseSizeFromEnv("PC_CLI_MAX_JSON_BYTES", DefaultMaxJSONBytes)
+	MaxBodyJSONBytes int64 = parseSizeFromEnv("PINECONE_CLI_MAX_JSON_BYTES", DefaultMaxJSONBytes)
 )
 
 // parseSizeFromEnv parses a size from an environment variable with a default value.


### PR DESCRIPTION
## Problem

`AGENTS.md` and `README.md` were last updated before several significant PRs landed (#84–#92) and still carried public-preview language, stale command references, and large gaps in coverage.

## Solution

**`README.md`**
- Removed the public-preview warning banner
- Fixed two legacy `pc config set-api-key` references → `pc config set api-key`
- Fixed `pc index upsert` → `pc index vector upsert` in the working-with-data intro
- Expanded the data-plane overview: reorganized `pc index vector` commands under a "dense/sparse vectors" subheading, added `pc index record` (integrated indexes) and `pc index namespace` entries
- Added a new "Index management commands" section covering `pc index backup`, `pc index restore`, `pc index import`, and `pc index collection`

**`AGENTS.md`**
- Removed "public preview" from the project description
- Corrected the VectorDB root group (collection/backup/restore now live under `pc index`, not at the root)
- Added `pc index` internal subgroup table (Data, Namespace, Index Management including the new `import`)
- Documented the canonical `pc config` key-based interface (`get`/`set`/`unset`/`list`/`describe`)
- Added `scripts/` to the key directories table
- Added a new "Patterns for writing commands" section covering: output/error/exit packages (`msg`, `style`, `exit`, `text`), help-text helpers, custom JSON flag types, the narrow-interface testability pattern, target org/project access, and logging
- Added a "Notable environment variables" table (`PINECONE_API_KEY`, `PINECONE_ENVIRONMENT`, `PINECONE_LOG_LEVEL`, `PINECONE_CLI_MAX_JSON_BYTES`)

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-code change (docs, etc)