### PR TITLE
feat: emit Claude Code plugin hint for the official Pinecone plugin

### DIFF
--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -67,12 +67,9 @@ type GlobalOptions struct {
 }
 
 func Execute() {
-	// If running inside Claude Code, emit a one-line marker prompting the user
-	// to install the official Pinecone plugin. Placed here (rather than in a
-	// PersistentPreRun) so it fires for every invocation — including --help and
-	// unknown-command errors — regardless of any subcommand PersistentPreRun
-	// overrides. Claude Code strips the marker from the output before it reaches
-	// the model, so it never appears in the conversation.
+	// Recommend the Pinecone plugin when running inside Claude Code. Done here
+	// rather than in a PersistentPreRun so it fires for every invocation,
+	// including --help and unknown-command errors.
 	pluginhint.Emit()
 
 	// Base context: cancel on SIGINT / SIGTERM

--- a/internal/pkg/cli/command/root/root.go
+++ b/internal/pkg/cli/command/root/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pinecone-io/cli/internal/pkg/utils/help"
 	loginutil "github.com/pinecone-io/cli/internal/pkg/utils/login"
 	"github.com/pinecone-io/cli/internal/pkg/utils/msg"
+	"github.com/pinecone-io/cli/internal/pkg/utils/pluginhint"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +67,14 @@ type GlobalOptions struct {
 }
 
 func Execute() {
+	// If running inside Claude Code, emit a one-line marker prompting the user
+	// to install the official Pinecone plugin. Placed here (rather than in a
+	// PersistentPreRun) so it fires for every invocation — including --help and
+	// unknown-command errors — regardless of any subcommand PersistentPreRun
+	// overrides. Claude Code strips the marker from the output before it reaches
+	// the model, so it never appears in the conversation.
+	pluginhint.Emit()
+
 	// Base context: cancel on SIGINT / SIGTERM
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 

--- a/internal/pkg/utils/pluginhint/pluginhint.go
+++ b/internal/pkg/utils/pluginhint/pluginhint.go
@@ -1,0 +1,66 @@
+// Package pluginhint emits a one-line marker that prompts Claude Code users to
+// install the official Pinecone plugin.
+//
+// When the CLI detects it is running inside Claude Code (via the CLAUDECODE or
+// CLAUDE_CODE_CHILD_SESSION environment variables), it writes a self-closing
+// <claude-code-hint /> tag to stderr on its own line. Claude Code reads the
+// marker, strips it from the command output before it reaches the model (so it
+// never appears in the conversation or counts toward tokens), and shows the
+// user a one-time prompt to install the plugin.
+//
+// The protocol is documented at https://code.claude.com/docs/en/plugin-hints.
+package pluginhint
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+// hintLine is the marker Claude Code looks for. It must occupy its own line and
+// reference a plugin in an official Anthropic-controlled marketplace, otherwise
+// Claude Code drops it.
+//
+//	v     — protocol version (1 is the only supported value)
+//	type  — hint kind (plugin is the only supported value)
+//	value — plugin identifier in name@marketplace form
+const hintLine = `<claude-code-hint v="1" type="plugin" value="pinecone@claude-plugins-official" />`
+
+// once guards against emitting the hint more than once per process. Claude Code
+// deduplicates by plugin, so a single emission per invocation is all that's
+// needed even though Emit may be reachable from multiple code paths.
+var once sync.Once
+
+// inClaudeCode reports whether the CLI appears to be running inside a Claude
+// Code session.
+//
+//   - CLAUDECODE is set on every Claude Code version, giving the widest reach.
+//   - CLAUDE_CODE_CHILD_SESSION is set (v2.1.172+) only in subprocesses Claude
+//     Code itself spawns, such as Bash tool calls.
+//
+// Gating on either keeps the marker out of normal human-run invocations.
+func inClaudeCode() bool {
+	return os.Getenv("CLAUDECODE") != "" || os.Getenv("CLAUDE_CODE_CHILD_SESSION") != ""
+}
+
+// Emit writes the plugin hint to stderr when running inside Claude Code. It is
+// safe to call from any number of code paths and on every invocation; the hint
+// is written at most once per process and is a no-op outside Claude Code.
+//
+// stderr keeps the tag out of shell pipelines (e.g. `pc index list | jq`),
+// though Claude Code scans both streams.
+func Emit() {
+	emitTo(os.Stderr)
+}
+
+// emitTo is the testable core of Emit.
+func emitTo(w io.Writer) {
+	if !inClaudeCode() {
+		return
+	}
+	once.Do(func() {
+		// Written on its own line; the trailing newline is required so the tag
+		// occupies a line by itself.
+		_, _ = io.WriteString(w, hintLine+"\n")
+	})
+}

--- a/internal/pkg/utils/pluginhint/pluginhint.go
+++ b/internal/pkg/utils/pluginhint/pluginhint.go
@@ -1,14 +1,8 @@
-// Package pluginhint emits a one-line marker that prompts Claude Code users to
-// install the official Pinecone plugin.
-//
-// When the CLI detects it is running inside Claude Code (via the CLAUDECODE or
-// CLAUDE_CODE_CHILD_SESSION environment variables), it writes a self-closing
-// <claude-code-hint /> tag to stderr on its own line. Claude Code reads the
-// marker, strips it from the command output before it reaches the model (so it
-// never appears in the conversation or counts toward tokens), and shows the
-// user a one-time prompt to install the plugin.
-//
-// The protocol is documented at https://code.claude.com/docs/en/plugin-hints.
+// Package pluginhint implements the Claude Code plugin-hint protocol: when the
+// CLI runs inside Claude Code, it writes a marker to stderr that prompts the
+// user to install the official Pinecone plugin. Claude Code strips the marker
+// from the output before it reaches the model and shows a one-time install
+// prompt. See https://code.claude.com/docs/en/plugin-hints.
 package pluginhint
 
 import (
@@ -17,50 +11,30 @@ import (
 	"sync"
 )
 
-// hintLine is the marker Claude Code looks for. It must occupy its own line and
-// reference a plugin in an official Anthropic-controlled marketplace, otherwise
-// Claude Code drops it.
-//
-//	v     — protocol version (1 is the only supported value)
-//	type  — hint kind (plugin is the only supported value)
-//	value — plugin identifier in name@marketplace form
+// hintLine must occupy its own line and reference a plugin in an official
+// Anthropic marketplace; Claude Code drops hints that don't.
 const hintLine = `<claude-code-hint v="1" type="plugin" value="pinecone@claude-plugins-official" />`
 
-// once guards against emitting the hint more than once per process. Claude Code
-// deduplicates by plugin, so a single emission per invocation is all that's
-// needed even though Emit may be reachable from multiple code paths.
 var once sync.Once
 
-// inClaudeCode reports whether the CLI appears to be running inside a Claude
-// Code session.
-//
-//   - CLAUDECODE is set on every Claude Code version, giving the widest reach.
-//   - CLAUDE_CODE_CHILD_SESSION is set (v2.1.172+) only in subprocesses Claude
-//     Code itself spawns, such as Bash tool calls.
-//
-// Gating on either keeps the marker out of normal human-run invocations.
+// CLAUDECODE is set on every Claude Code version; CLAUDE_CODE_CHILD_SESSION
+// (v2.1.172+) only in subprocesses it spawns, such as Bash tool calls.
 func inClaudeCode() bool {
 	return os.Getenv("CLAUDECODE") != "" || os.Getenv("CLAUDE_CODE_CHILD_SESSION") != ""
 }
 
 // Emit writes the plugin hint to stderr when running inside Claude Code. It is
-// safe to call from any number of code paths and on every invocation; the hint
-// is written at most once per process and is a no-op outside Claude Code.
-//
-// stderr keeps the tag out of shell pipelines (e.g. `pc index list | jq`),
-// though Claude Code scans both streams.
+// a no-op otherwise, and emits at most once per process, so it is safe to call
+// on every invocation and from multiple code paths.
 func Emit() {
 	emitTo(os.Stderr)
 }
 
-// emitTo is the testable core of Emit.
 func emitTo(w io.Writer) {
 	if !inClaudeCode() {
 		return
 	}
 	once.Do(func() {
-		// Written on its own line; the trailing newline is required so the tag
-		// occupies a line by itself.
 		_, _ = io.WriteString(w, hintLine+"\n")
 	})
 }

--- a/internal/pkg/utils/pluginhint/pluginhint_test.go
+++ b/internal/pkg/utils/pluginhint/pluginhint_test.go
@@ -1,0 +1,90 @@
+package pluginhint
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// resetOnce restores the package-level once guard so each test starts fresh.
+func resetOnce() {
+	once = sync.Once{}
+}
+
+func TestEmitTo_WritesHintWhenInClaudeCode(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "CLAUDECODE set", env: map[string]string{"CLAUDECODE": "1"}},
+		{name: "CLAUDE_CODE_CHILD_SESSION set", env: map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}},
+		{name: "both set", env: map[string]string{"CLAUDECODE": "1", "CLAUDE_CODE_CHILD_SESSION": "1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetOnce()
+			t.Setenv("CLAUDECODE", "")
+			t.Setenv("CLAUDE_CODE_CHILD_SESSION", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			var buf bytes.Buffer
+			emitTo(&buf)
+
+			got := buf.String()
+			if got != hintLine+"\n" {
+				t.Errorf("emitTo() = %q, want %q", got, hintLine+"\n")
+			}
+		})
+	}
+}
+
+func TestEmitTo_NoopOutsideClaudeCode(t *testing.T) {
+	resetOnce()
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "")
+
+	var buf bytes.Buffer
+	emitTo(&buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("emitTo() wrote %q outside Claude Code, want nothing", buf.String())
+	}
+}
+
+func TestEmitTo_OnlyEmitsOnce(t *testing.T) {
+	resetOnce()
+	t.Setenv("CLAUDECODE", "1")
+
+	var buf bytes.Buffer
+	emitTo(&buf)
+	emitTo(&buf)
+	emitTo(&buf)
+
+	if got := strings.Count(buf.String(), "claude-code-hint"); got != 1 {
+		t.Errorf("emitTo() emitted hint %d times, want 1", got)
+	}
+}
+
+func TestHintLine_MatchesProtocol(t *testing.T) {
+	// The tag must be self-closing with the three required attributes, target
+	// the official marketplace, and contain no newline (it must occupy a single
+	// line; emitTo appends the terminating newline).
+	if strings.Contains(hintLine, "\n") {
+		t.Errorf("hintLine must not contain a newline: %q", hintLine)
+	}
+	for _, want := range []string{
+		`v="1"`,
+		`type="plugin"`,
+		`value="pinecone@claude-plugins-official"`,
+		"<claude-code-hint",
+		"/>",
+	} {
+		if !strings.Contains(hintLine, want) {
+			t.Errorf("hintLine missing %q; got %q", want, hintLine)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the [Claude Code plugin-hint protocol](https://code.claude.com/docs/en/plugin-hints). When `pc` runs inside a Claude Code session, it writes a one-line marker to stderr recommending the official Pinecone plugin:

```
<claude-code-hint v="1" type="plugin" value="pinecone@claude-plugins-official" />
```

Claude Code strips this line from the command output before it reaches the model (so it never appears in the conversation or counts toward tokens) and shows the user a **one-time** prompt to install the plugin. Installation always requires explicit user confirmation.

## What the user sees

- **Running `pc` directly in a terminal:** no change at all — emission is gated on env vars that Claude Code sets, so a no-op otherwise.
- **Running `pc` through Claude Code:** a one-time install prompt naming the `pinecone` plugin. Rate-limited to once per plugin (ever) and once per Claude Code session.

## Changes

- New `internal/pkg/utils/pluginhint` package:
  - Emits the marker to **stderr** on its own line.
  - Gated on **either** `CLAUDECODE` or `CLAUDE_CODE_CHILD_SESSION` being set.
  - `sync.Once`-guarded — emits at most once per process.
- Wired into `root.Execute()` so it fires for **every** invocation (including `--help` and unknown-command errors), regardless of any subcommand `PersistentPreRun` overrides.
- Unit tests covering emission per env var, no-op outside Claude Code, emit-once behavior, and protocol conformance of the hint string.

## Notes for reviewers

- ⚠️ **The hint only takes effect once a plugin named `pinecone` is listed in the official `claude-plugins-official` marketplace.** Hints pointing at any other marketplace are silently dropped by Claude Code. If the official listing uses a different name, update `hintLine` in `pluginhint.go` (and the matching test assertion).
- ⚠️ I was unable to run `go build` / `go test` / `go vet` locally (Go isn't installed on the dev machine). Please confirm CI is green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated on Claude Code env vars and only adds optional stderr output with no changes to auth, API calls, or normal terminal usage.
> 
> **Overview**
> Adds **Claude Code plugin-hint** support so `pc` can suggest installing `pinecone@claude-plugins-official` when the CLI runs inside a Claude Code session.
> 
> A new `pluginhint` helper writes a single protocol line to **stderr** only when `CLAUDECODE` or `CLAUDE_CODE_CHILD_SESSION` is set, guarded by `sync.Once` so it fires at most once per process. Outside Claude Code it is a no-op.
> 
> `root.Execute()` calls `pluginhint.Emit()` before Cobra runs so the hint applies to every invocation (including `--help` and unknown commands), not only subcommands that run `PersistentPreRun`. Unit tests cover env detection, no-op behavior, emit-once, and the hint string format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb1bd9db415b567d11efc1f5fbacea238b07522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->