### PR TITLE
Enable Dependabot version updates (PIN-4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      gomod-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` enabling **weekly, grouped Dependabot version updates**.

Ecosystems covered: gomod, github-actions.

## Why
Part of standing up the security fast-patch process (**PIN-4**). Keeping dependencies close to their latest patched release shrinks the diff and time needed to ship a fix when a security advisory lands. Dependabot **security updates** (auto patch PRs on advisories) and **vulnerability alerts** are already enabled on this repo; this adds the routine version-update cadence.

Minor/patch updates are grouped into a single PR per ecosystem to keep review noise low; majors come as individual PRs.

## Review notes
Config only — no code changes. First run may open a batch of update PRs; that is expected. Adjust `open-pull-requests-limit` or `schedule` if the cadence is too noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to dependency automation; no runtime or application logic is modified.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so Dependabot opens routine **weekly** version-update PRs for **Go modules** and **GitHub Actions**, complementing existing security advisories and alerts (PIN-4).
> 
> **Go (`gomod`)** updates run from repo root with up to **10** open PRs; **minor** and **patch** bumps are **grouped** into one PR, while **major** updates stay separate. **GitHub Actions** updates are also weekly, with all action bumps **grouped** under a single pattern.
> 
> No application code changes—only CI/dependency automation config. The first Dependabot run may open a batch of update PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cd36834ae2163a0eb3af61a77442e219f6077a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->