### PR TITLE
Bump go directive to 1.25.0 to unblock Dependabot PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pinecone-io/cli
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/internal/pkg/utils/presenters/text.go
+++ b/internal/pkg/utils/presenters/text.go
@@ -27,7 +27,7 @@ func DisplayOrNone(val any) string {
 	v := reflect.ValueOf(val)
 	for v.IsValid() {
 		switch v.Kind() {
-		case reflect.Ptr, reflect.Interface:
+		case reflect.Pointer, reflect.Interface:
 			if v.IsNil() {
 				return nonePlaceholder
 			}


### PR DESCRIPTION
## Problem

Five of the six open Dependabot PRs pull in dependencies that declare `go 1.25.0` in their own `go.mod` — `golang.org/x/*` (which raised its floor to 1.25), `fatih/color`, and `google.golang.org/grpc`. Since Go 1.21 the main module's `go` directive must be at least as high as every dependency's, so `go mod tidy` raises it automatically. The bump is forced, not discretionary.

That bump makes CI's `lint` job run under Go 1.25 (it resolves the toolchain from `go-version-file: go.mod`), and Go 1.25's `go vet` adds the `inline` analyzer. It flags one pre-existing line of first-party code — which is why #109 and #113 currently fail lint for a reason unrelated to their dependencies:

```
internal/pkg/utils/presenters/text.go:30:8: inline: Constant reflect.Ptr should be inlined (govet)
```

## Solution

Land the forced bump and the fix it surfaces on `main` first, so the Dependabot PRs rebase onto a green baseline:

- `go.mod`: `go 1.24.0` → `go 1.25.0`
- `text.go`: `reflect.Ptr` → `reflect.Pointer` (`const Ptr = Pointer` in the stdlib — the same constant, so no behavior change)

No `toolchain` directive is added, so `GOTOOLCHAIN=auto` users fetch 1.25 transparently. Note the `go` line also selects GODEBUG defaults, so this raises the runtime compatibility baseline to 1.25 as well.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [x] None of the above: Go toolchain floor bump, prerequisite for the open Dependabot PRs.

## Test Plan

- `lint` (Go 1.25 + golangci-lint v2.12.2): `0 issues`
- `unit-tests`, `goreleaser-build`, CodeQL: pass
- Local: `go build ./...` and `go vet ./...` clean, `go test ./...` 23/23 packages pass
- Post-merge: `@dependabot rebase` on #113 then #109, confirm lint goes green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and a single reflect constant rename with no behavior change to CLI output logic.
> 
> **Overview**
> Raises the module’s minimum Go version from **1.24.0** to **1.25.0** in `go.mod` so the repo can take newer dependency updates (including Dependabot bumps).
> 
> Updates `DisplayOrNone` in `text.go` to use **`reflect.Pointer`** instead of the deprecated **`reflect.Ptr`** in the kind switch, matching Go 1.25’s reflect API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ffe1013e8bf68f6911e9f922152985d1a60418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
