### PR TITLE
Add go-version-file to setup-go where it's missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: Run tests
         run: go test -v ./...
 
@@ -55,6 +57,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: Setup Google service account creds
         id: setup-google
         run: |


### PR DESCRIPTION
## Problem

`unit-tests` and `goreleaser-build` in `ci.yaml`, plus the publish job in `publish.yaml`, called `actions/setup-go` with no version, so they ran on the runner's default Go rather than the version the module declares. Only `lint` and `e2e` pinned via `go-version-file`.

That was harmless until `setup-go@v6` (#108) began resolving unpinned to go1.24.13 with `GOTOOLCHAIN=local`, which hard-fails against `go 1.25.0` (#114) instead of fetching a newer toolchain. Both PRs were green individually — the break only appeared once both were on `main`:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

`publish.yaml` was affected too. `.goreleaser.yaml`'s before-hooks (`go mod tidy`, `go generate ./...`, `go run ./cmd/gen-manpages`) all invoke Go, so the next `v*` tag would have failed the release.

## Solution

Add `go-version-file: go.mod` to the three unpinned `setup-go` steps, matching what `lint` and `e2e` already do. Every job now builds and tests against the declared Go version.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

- `unit-tests` and `goreleaser-build` now report `Setup go version spec 1.25.0` → `go version go1.25.0` and pass
- All checks green, including `e2e` and `goreleaser-build`
- Note: open Dependabot PRs (#109, #110, #113) need rebasing onto this fix before their CI results are meaningful — #110's current green run predates #108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweaks with no application or runtime behavior changes.
> 
> **Overview**
> **CI Go setup** now reads the toolchain from `go.mod` everywhere `actions/setup-go@v6` runs, matching what the **lint** job already did.
> 
> The change adds `with: go-version-file: go.mod` to **unit-tests** and **goreleaser-build** in `ci.yaml`, and to the publish job in `publish.yaml`. Tests and release builds will use the same Go version declared in the module (e.g. `go 1.25.0`) instead of the action’s default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c109c1d8d7abab4641a3f40681b5d15074eae15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
